### PR TITLE
Make prescient-filter-method accept a list of builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### New features
+* The user option `prescient-filter-method` now accepts a list of
+  filter methods that will be applied in order until one matches. This
+  changes the new default changed from `literal+initialism` to
+  `(literal initialism)`, which is functionally equivalent. This
+  allows for any combination of filter methods ([#29]).
+
+[#29]: https://github.com/raxod502/prescient.el/issues/29
+
 ## 2.2.2 (released 2019-02-12)
 ### Enhancements
 * The Custom groups for the user options `prescient-persist-mode`,

--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ pressing `C-c C-r`.
   [`no-littering`][no-littering].
 
 * `prescient-filter-method`: Which algorithm to use for filtering
-  candidates. The default is `literal+initialism` as described above,
-  but you can also use substring matching, initialism matching, regexp
-  matching, or fuzzy matching. See the docstring for full details.
+  candidates. The default is `literal` and `initialism` as described
+  above, but you can also use substring matching, initialism matching,
+  regexp matching, fuzzy matching, or any combination of those. See
+  the docstring for full details.
 
 * `ivy-prescient-excluded-commands`: Some commands, like `swiper`,
   don't benefit from `prescient.el` sorting, so their usage statistics

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pressing `C-c C-r`.
   default value follows the conventions of
   [`no-littering`][no-littering].
 
-* `prescient-filter-method`: Which algorithm to use for filtering
+* `prescient-filter-method`: A list of algorithms to use for filtering
   candidates. The default is `literal` and `initialism` as described
   above, but you can also use substring matching, initialism matching,
   regexp matching, fuzzy matching, or any combination of those. See

--- a/prescient.el
+++ b/prescient.el
@@ -79,15 +79,14 @@ This only has an effect if `prescient-persist-mode' is enabled."
   :type 'file)
 
 (defvar prescient--filter-method-custom-type
-  '(choice
+  '(set
     (const :tag "Literal" literal)
-    (const :tag "Initialism" initialism)
-    (const :tag "Literal and initialism" literal+initialism)
     (const :tag "Regexp" regexp)
+    (const :tag "Initialism" initialism)
     (const :tag "Fuzzy" fuzzy))
   "Value for `:type' field in `prescient-filter-method' defcustom.")
 
-(defcustom prescient-filter-method 'literal+initialism
+(defcustom prescient-filter-method '(literal initialism)
   "How to interpret prescient.el filtering queries.
 Queries are first split on spaces (with two consecutive spaces)
 standing for a literal space. Then, the candidates are filtered
@@ -97,18 +96,18 @@ filtering takes place.
 Value `literal' means the subquery must be a substring of the
 candidate.
 
-Value `initialism' means the subquery must match a substring of
-the initials of the candidate.
-
-Value `literal+initialism' means the subquery must be either a
-substring or an initialism.
-
 Value `regexp' means the subquery is interpreted directly as a
 regular expression.
 
+Value `initialism' means the subquery must match a substring of
+the initials of the candidate.
+
 Value `fuzzy' means the characters of the subquery must match
 some subset of those of the candidate, in the correct order but
-not necessarily contiguous."
+not necessarily contiguous.
+
+Value can also be a list of any of the above methods, in which
+case each method will be applied in order until one matches."
   :type prescient--filter-method-custom-type)
 
 ;;;; Caches
@@ -298,29 +297,29 @@ with capture groups. If it is the symbol `all', additionally
 enclose literal substrings with capture groups."
   (mapcar
    (lambda (subquery)
-     (pcase prescient-filter-method
-       (`literal
-        (prescient--with-group
-         (regexp-quote subquery)
-         (eq with-groups 'all)))
-       (`initialism
-        (prescient--initials-regexp subquery with-groups))
-       (`literal+initialism
-        (format "%s\\|%s"
-                (prescient--with-group
-                 (regexp-quote subquery)
-                 (eq with-groups 'all))
-                (prescient--initials-regexp subquery with-groups)))
-       (`regexp
-        subquery)
-       (`fuzzy
-        (mapconcat
-         (lambda (char)
+     (mapconcat
+      (lambda (method)
+        (pcase method
+          (`literal
            (prescient--with-group
-            (regexp-quote
-             (char-to-string char))
-            with-groups))
-         subquery ".*"))))
+            (regexp-quote subquery)
+            (eq with-groups 'all)))
+          (`initialism
+           (prescient--initials-regexp subquery with-groups))
+          (`regexp
+           subquery)
+          (`fuzzy
+           (mapconcat
+            (lambda (char)
+              (prescient--with-group
+               (regexp-quote
+                (char-to-string char))
+               with-groups))
+            subquery ".*"))))
+      (if (listp prescient-filter-method)
+          prescient-filter-method
+        (list prescient-filter-method))
+      "\\|"))
    (prescient-split-query query)))
 
 (defun prescient-filter (query candidates)

--- a/prescient.el
+++ b/prescient.el
@@ -107,7 +107,12 @@ some subset of those of the candidate, in the correct order but
 not necessarily contiguous.
 
 Value can also be a list of any of the above methods, in which
-case each method will be applied in order until one matches."
+case each method will be applied in order until one matches.
+
+
+For backwards compatibility, the value of this variable can also
+be `literal+initialism', which equivalent to the list (`literal'
+`initialism')."
   :type prescient--filter-method-custom-type)
 
 ;;;; Caches
@@ -315,7 +320,10 @@ enclose literal substrings with capture groups."
                (regexp-quote
                 (char-to-string char))
                with-groups))
-            subquery ".*"))))
+            subquery ".*"))
+          (`literal+initialism ;; For backwards compatibility
+           (let ((prescient-filter-method '(literal initialism)))
+             (car (prescient-filter-regexps subquery with-groups))))))
       (if (listp prescient-filter-method)
           prescient-filter-method
         (list prescient-filter-method))

--- a/prescient.el
+++ b/prescient.el
@@ -320,13 +320,11 @@ enclose literal substrings with capture groups."
                (regexp-quote
                 (char-to-string char))
                with-groups))
-            subquery ".*"))
-          (`literal+initialism ;; For backwards compatibility
-           (let ((prescient-filter-method '(literal initialism)))
-             (car (prescient-filter-regexps subquery with-groups))))))
-      (if (listp prescient-filter-method)
-          prescient-filter-method
-        (list prescient-filter-method))
+            subquery ".*"))))
+      (pcase prescient-filter-method
+        (`literal+initialism '(literal initialism)) ;; For backwards compatibility
+        ((and (pred listp) x) x)
+        (x (list x)))
       "\\|"))
    (prescient-split-query query)))
 


### PR DESCRIPTION
Closes #29. Make `precient-filter-method` accept a list of regexp builders, which will be applied in order. This allows for many combinations suited to the user and the backend.

Originally I was going to leave the default `literal+initialism` for backward compatibility, but I think since it is the default it will be very rare for the user to have explicitly set it, which means the new default (`(literal initialism)`, which is functionally equivalent) will just work.