### PR TITLE
Add controls for sorting and filtering in ivy-prescient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog].
 ## Unreleased
 ### New features
 * Two new user options, `ivy-prescient-enable-filtering` and
-  `ivy-prescient-enable-sorting` which control filtering and adaptive
-  sorting respectively ([#32]).
+  `ivy-prescient-enable-sorting`, which allow the user to selectively
+  disable the filtering or sorting functionalities of
+  `ivy-prescient.el` ([#32]).
 
 [#32]: https://github.com/raxod502/prescient.el/issues/32
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### New features
+* Two new user options, `ivy-prescient-enable-filtering` and
+  `ivy-prescient-enable-sorting` which control filtering and adaptive
+  sorting respectively ([#32]).
+
+[#32]: https://github.com/raxod502/prescient.el/issues/32
+
 ## 2.2.2 (released 2019-02-12)
 ### Enhancements
 * The Custom groups for the user options `prescient-persist-mode`,

--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ pressing `C-c C-r`.
   recover the original behavior by customizing this user option; see
   the docstring for more details.
 
+* `ivy-prescient-override-filter-method`: If non-nil, override the
+  default in `ivy-re-builder-alist` with `prescient-filter-method`.
+  You can set this to nil to retain filter functions set by ivy.
+
+* `ivy-prescient-adaptive-sorting`: If non-nil, use adapative sorting
+  for ivy collections. This will override the default in
+  `ivy-sort-functions-alist`. YOu can set this to nil to retain
+  default ivy sorting.
+
 ## Known bugs
 
 If you are using release 0.10.0 of Ivy, you will notice a number of

--- a/README.md
+++ b/README.md
@@ -111,13 +111,15 @@ pressing `C-c C-r`.
   recover the original behavior by customizing this user option; see
   the docstring for more details.
 
-* `ivy-prescient-enable-filtering`: If non-nil, filter Ivy collections
-  with `prescient-filter-method`. You can set this to nil to retain
-  default filter functions set by ivy.
+* `ivy-prescient-enable-filtering`: If set to nil, then
+  `ivy-prescient.el` does not apply `prescient.el` filtering to Ivy.
+  See the Ivy documentation for information on how Ivy filters by
+  default, and how to customize it manually.
 
-* `ivy-prescient-enable-sorting`: If non-nil, use adapative sorting
-  for ivy collections. You can set this to nil to retain default ivy
-  sorting.
+* `ivy-prescient-enable-sorting`: If set to nil, then
+  `ivy-prescient.el` does not apply `prescient.el` sorting to Ivy. See
+  the Ivy documentation for information on how Ivy sorts by default,
+  and how to customize it manually.
 
 ## Known bugs
 

--- a/README.md
+++ b/README.md
@@ -111,14 +111,13 @@ pressing `C-c C-r`.
   recover the original behavior by customizing this user option; see
   the docstring for more details.
 
-* `ivy-prescient-override-filter-method`: If non-nil, override the
-  default in `ivy-re-builder-alist` with `prescient-filter-method`.
-  You can set this to nil to retain filter functions set by ivy.
+* `ivy-prescient-enable-filtering`: If non-nil, filter Ivy collections
+  with `prescient-filter-method`. You can set this to nil to retain
+  default filter functions set by ivy.
 
-* `ivy-prescient-adaptive-sorting`: If non-nil, use adapative sorting
-  for ivy collections. This will override the default in
-  `ivy-sort-functions-alist`. YOu can set this to nil to retain
-  default ivy sorting.
+* `ivy-prescient-enable-sorting`: If non-nil, use adapative sorting
+  for ivy collections. You can set this to nil to retain default ivy
+  sorting.
 
 ## Known bugs
 

--- a/ivy-prescient.el
+++ b/ivy-prescient.el
@@ -100,23 +100,21 @@ out-of-order matching."
   :group 'prescient
   :type 'boolean)
 
-(defcustom ivy-prescient-override-filter-method t
-  "Whether to override default ivy re-builder with `prescient-filter-method'.
- Individual collection functions can still be overriden using
-`ivy-re-builders-alist'. This will also disable
-`ivy-initial-inputs-alist' since the only filter method that
-supports it is `regexp'. Changing this variable will not take
-effect until `ivy-prescient-mode' has been reloaded."
+(defcustom ivy-prescient-enable-filtering t
+  "Whether to enable filtering of ivy colections with `prescient-filter-method'.
+ If nil, then `ivy-prescient-mode' does not change the filtering
+behavior of Ivy from the default. See Ivy documentation for how to
+configure filtering yourself. Changing this variable will not
+take effect until `ivy-prescient-mode' has been reloaded."
   :group 'prescient
   :type 'boolean)
 
-(defcustom ivy-prescient-adaptive-sorting t
+(defcustom ivy-prescient-enable-sorting t
   "Whether to use adaptive sorting in ivy collections.
-Invividual collection functions can still be overriden using
-`ivy-sort-functions-alist'. Note that
-`ivy-prescient-sort-commands' enables sorting of collections not
-normally supported. Changing this variable will not take effect
-until `ivy-prescient-mode' has been reloaded."
+If nil, then `ivy-prescient-mode' does not change the sorting
+behavior of Ivy from the default. See Ivy documentation for how
+to configure sorting yourself. Changing this variable will not
+take effect until `ivy-prescient-mode' has been reloaded."
   :group 'prescient
   :type 'boolean)
 
@@ -276,14 +274,14 @@ keyword arguments ACTION, CALLER are the same as in `ivy-read'."
   :group 'prescient
   (if ivy-prescient-mode
       (progn
-        (when ivy-prescient-override-filter-method
+        (when ivy-prescient-enable-filtering
           (setq ivy-prescient--old-re-builder
                 (alist-get t ivy-re-builders-alist))
           (setf (alist-get t ivy-re-builders-alist)
                 #'ivy-prescient-re-builder)
           (setq ivy-prescient--old-initial-inputs-alist ivy-initial-inputs-alist)
           (setq ivy-initial-inputs-alist nil))
-        (when ivy-prescient-adaptive-sorting
+        (when ivy-prescient-enable-sorting
           (setq ivy-prescient--old-ivy-sort-function
                 (alist-get t ivy-sort-functions-alist))
           (setf (alist-get t ivy-sort-functions-alist)

--- a/ivy-prescient.el
+++ b/ivy-prescient.el
@@ -102,7 +102,7 @@ out-of-order matching."
 
 (defcustom ivy-prescient-enable-filtering t
   "Whether to enable filtering of ivy colections with `prescient-filter-method'.
- If nil, then `ivy-prescient-mode' does not change the filtering
+If nil, then `ivy-prescient-mode' does not change the filtering
 behavior of Ivy from the default. See Ivy documentation for how to
 configure filtering yourself. Changing this variable will not
 take effect until `ivy-prescient-mode' has been reloaded."


### PR DESCRIPTION
As discussed in #29, enable controls to enable/disable sorting or filtering in ivy-prescient. This will give users the option to enable sorting or filter or both. Closes #32.