### PR TITLE
Renable ivy-prescient file completion and add regexp to the default filter method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ The format is based on [Keep a Changelog].
 
 ### Bugs fixed
 * Fixed completion in file-name based collections ([#28])
-* Fixed an issue where ivy actions that accepted a list of candidates were
-  being handled incorrectly ([#33])
+* Fixed an issue where ivy actions that accepted a list of candidates
+  were being handled incorrectly ([#33])
 
 [#28]: https://github.com/raxod502/prescient.el/issues/28
 [#33]: https://github.com/raxod502/prescient.el/issues/33

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
 ## Unreleased
+
+### Bugs fixed
+* Fixed completion in file-name based collections ([#28])
+* Fixed an issue where ivy actions that accepted a list of candidates were
+  being handled incorrectly ([#33])
+
+[#28]: https://github.com/raxod502/prescient.el/issues/28
+[#33]: https://github.com/raxod502/prescient.el/issues/33
+
+### Deprecated
+* Removed `ivy-prescient-filter-method-keys` and
+  `ivy-prescient-persist-filter-method` because `regexp` is now part
+  of the default filter method, and therefore these are no longer
+  needed ([#15], [#24], and [#27]).
+* Removed `ivy-prescient-excluded-commands` because ivy-prescient now
+  automatically detects if sorting is enabled in a collection
+
+[#15]: https://github.com/raxod502/prescient.el/issues/15
+[#24]: https://github.com/raxod502/prescient.el/issues/24
+[#27]: https://github.com/raxod502/prescient.el/issues/27
+
 ### New features
 * The user option `prescient-filter-method` now accepts a list of
   filter methods that will be applied in order until one matches. This

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,40 +4,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
 ## Unreleased
-
-### Bugs fixed
-* Fixed completion in file-name based collections ([#28])
-* Fixed an issue where ivy actions that accepted a list of candidates
-  were being handled incorrectly ([#33])
-
-[#28]: https://github.com/raxod502/prescient.el/issues/28
-[#33]: https://github.com/raxod502/prescient.el/issues/33
-
-### Deprecated
-* Removed `ivy-prescient-filter-method-keys` and
-  `ivy-prescient-persist-filter-method` because `regexp` is now part
-  of the default filter method, and therefore these are no longer
-  needed ([#15], [#24], and [#27]).
-* Removed `ivy-prescient-excluded-commands` because ivy-prescient now
-  automatically detects if sorting is enabled in a collection
-
-[#15]: https://github.com/raxod502/prescient.el/issues/15
-[#24]: https://github.com/raxod502/prescient.el/issues/24
-[#27]: https://github.com/raxod502/prescient.el/issues/27
-
 ### New features
 * The user option `prescient-filter-method` now accepts a list of
   filter methods that will be applied in order until one matches. This
-  changes the new default changed from `literal+initialism` to
-  `(literal initialism)`, which is functionally equivalent. This
-  allows for any combination of filter methods ([#29]).
+  allows for any combination of filter methods ([#29]). The default
+  value has changed from `literal+initialism` to `(literal regexp
+  initialism)`, which provides a superset of functionality.
 * Two new user options, `ivy-prescient-enable-filtering` and
   `ivy-prescient-enable-sorting`, which allow the user to selectively
   disable the filtering or sorting functionalities of
   `ivy-prescient.el` ([#32]).
 
+### Bugs fixed
+* Fixed sorting in filename-based collections ([#28]).
+* Fixed an issue where Ivy actions that accepted a list of candidates
+  were being handled incorrectly ([#33]).
+
+### Removed
+* Removed `ivy-prescient-filter-method-keys` and
+  `ivy-prescient-persist-filter-method` because `regexp` is now part
+  of the default filter method, and therefore these are no longer
+  needed ([#15], [#24], and [#27]).
+* Removed `ivy-prescient-excluded-commands` because `ivy-prescient.el`
+  now automatically detects if sorting is enabled in a collection.
+
+[#15]: https://github.com/raxod502/prescient.el/issues/15
+[#24]: https://github.com/raxod502/prescient.el/issues/24
+[#27]: https://github.com/raxod502/prescient.el/issues/27
+[#28]: https://github.com/raxod502/prescient.el/issues/28
 [#29]: https://github.com/raxod502/prescient.el/issues/29
 [#32]: https://github.com/raxod502/prescient.el/issues/32
+[#33]: https://github.com/raxod502/prescient.el/issues/33
 
 ## 2.2.2 (released 2019-02-12)
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -46,17 +46,10 @@ statistics to be saved between Emacs sessions, enable
 you type. The query is first split on spaces into subqueries (two
 consecutive spaces match a literal space). Each subquery filters the
 candidates because it must match as either a substring of the
-candidate or as an initialism (e.g. `ffap` matches
+candidate, a regexp, or an initialism (e.g. `ffap` matches
 `find-file-at-point`, and so does `fa`). The last few candidates you
 selected are displayed first, followed by the most frequently selected
 ones, and then the remaining candidates are sorted by length.
-
-If you don't like the algorithm used for filtering, you can choose a
-different one by customizing `prescient-filter-method`. For Ivy, you
-can set up keybindings for changing this value on the fly by
-customizing `ivy-prescient-filter-method-keys`; by default, you can
-toggle between substring/initialism matching and regexp matching by
-pressing `C-c C-r`.
 
 ## Configuration
 
@@ -79,15 +72,10 @@ pressing `C-c C-r`.
   [`no-littering`][no-littering].
 
 * `prescient-filter-method`: A list of algorithms to use for filtering
-  candidates. The default is `literal` and `initialism` as described
-  above, but you can also use substring matching, initialism matching,
-  regexp matching, fuzzy matching, or any combination of those. See
-  the docstring for full details.
-
-* `ivy-prescient-excluded-commands`: Some commands, like `swiper`,
-  don't benefit from `prescient.el` sorting, so their usage statistics
-  just pollute the save file. You can tell `prescient.el` about them
-  here.
+  candidates. The default is `literal`, `regexp`, and `initialism` as
+  described above, but you can also use substring matching, initialism
+  matching, regexp matching, fuzzy matching, or any combination of
+  those. See the docstring for full details.
 
 * `ivy-prescient-sort-commands`: Some [Counsel] commands, like
   `counsel-find-library`, intentionally disable sorting for their
@@ -95,16 +83,6 @@ pressing `C-c C-r`.
   by adding such commands here. (To check if a command disables
   sorting, inspect its source code and see if it calls `ivy-read` with
   a nil value for the `:sort` keyword argument.)
-
-* `ivy-prescient-filter-method-keys`: This is an alist which
-  `ivy-prescient.el` uses to establish additional temporary bindings
-  in `ivy-minibuffer-map`. These bindings allow you to quickly change
-  the value of `prescient-filter-method` while inside Ivy. See the
-  docstring for information about the format of this alist.
-
-* `ivy-prescient-persist-filter-method`: If non-nil, then changes made
-  to `prescient-filter-method` while Ivy is active persist until the
-  next time you use Ivy, instead of being reset once you leave.
 
 * `ivy-prescient-retain-classic-highlighting`: By default, the
   highlighting behavior of `ivy-prescient.el` is slightly different

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ candidates because it must match as either a substring of the
 candidate, a regexp, or an initialism (e.g. `ffap` matches
 `find-file-at-point`, and so does `fa`). The last few candidates you
 selected are displayed first, followed by the most frequently selected
-ones, and then the remaining candidates are sorted by length.
+ones, and then the remaining candidates are sorted by length. If you
+don't like the algorithm used for filtering, you can choose a
+different one by customizing `prescient-filter-method`.
 
 ## Configuration
 

--- a/ivy-prescient.el
+++ b/ivy-prescient.el
@@ -207,8 +207,10 @@ enabled."
                 (alist-get #'read-file-name-internal ivy-sort-functions-alist))
           (setf (alist-get #'read-file-name-internal ivy-sort-functions-alist)
                 #'ivy-prescient-sort-file-function)
-          (advice-add #'ivy-read :filter-args #'ivy-prescient-enable-extra-sort)
-          (advice-add #'ivy--get-action :filter-return #'ivy-prescient--wrap-action)))
+          (advice-add #'ivy-read :filter-args
+                      #'ivy-prescient-enable-extra-sort)
+          (advice-add #'ivy--get-action :filter-return
+                      #'ivy-prescient--wrap-action)))
     (when (equal (alist-get t ivy-re-builders-alist)
                  #'ivy-prescient-re-builder)
       (setf (alist-get t ivy-re-builders-alist)

--- a/ivy-prescient.el
+++ b/ivy-prescient.el
@@ -143,10 +143,19 @@ This is the value that was associated to
 (defvar ivy-prescient--old-initial-inputs-alist nil
   "Previous value of `ivy-initial-inputs-alist'.")
 
+(declare-function ivy-state-sort "ivy")
+(declare-function ivy-state-collection "ivy")
+(declare-function ivy--sort-function "ivy")
+(declare-function ivy--get-action "ivy")
+
 (defun ivy-prescient--wrap-action (action)
   "Wrap an action for use in `ivy-read'.
 ACTION is the original action, a function. Return a new function
 that also invokes `prescient-remember'."
+  (defvar ivy-marked-candidates)
+  (defvar ivy-last)
+  (defvar ivy--directory)
+  (declare-function 'ivy-state-collection "ivy")
   (if (or ivy-marked-candidates
           (not (memq (let ((sort (ivy-state-sort ivy-last))
                            (coll (ivy-state-collection ivy-last)))

--- a/ivy-prescient.el
+++ b/ivy-prescient.el
@@ -167,7 +167,7 @@ that also invokes `prescient-remember'."
 
 (defun ivy-prescient-enable-extra-sort (args)
   "Enable sorting of `ivy-prescient-sort-commands'.
- If the `:caller' passed to `ivy-read' is a member of
+If the `:caller' in ARGS is a member of
 `ivy-prescient-sort-commands', then `:sort' is unconditionally
 enabled."
   (append args (and (memq (plist-get args :caller)

--- a/ivy-prescient.el
+++ b/ivy-prescient.el
@@ -204,7 +204,7 @@ enabled."
             ivy-prescient--old-ivy-sort-function))
     (when (equal (alist-get #'read-file-name-internal
                             ivy-sort-functions-alist)
-                 #'ivy-prescient-sort-file-function)
+                 #'ivy-prescient-sort-function)
       (setf (alist-get #'read-file-name-internal ivy-sort-functions-alist)
             ivy-prescient--old-ivy-sort-file-function))
     (unless ivy-initial-inputs-alist

--- a/prescient.el
+++ b/prescient.el
@@ -86,7 +86,7 @@ This only has an effect if `prescient-persist-mode' is enabled."
     (const :tag "Fuzzy" fuzzy))
   "Value for `:type' field in `prescient-filter-method' defcustom.")
 
-(defcustom prescient-filter-method '(literal initialism)
+(defcustom prescient-filter-method '(literal regexp initialism)
   "How to interpret prescient.el filtering queries.
 Queries are first split on spaces (with two consecutive spaces)
 standing for a literal space. Then, the candidates are filtered

--- a/stub/ivy.el
+++ b/stub/ivy.el
@@ -5,7 +5,14 @@
 (defvar ivy-initial-inputs-alist nil)
 (defvar ivy-re-builders-alist nil)
 (defvar ivy-sort-functions-alist nil)
+(defvar ivy-marked-candidates nil)
+(defvar ivy-last nil)
+(defvar ivy--directory nil)
 
 (defun ivy-read (prompt collection &rest args))
+(defun ivy-state-sort (struct))
+(defun ivy-state-collection (struct))
+(defun ivy--sort-function (collection))
+(defun ivy--get-action (collection))
 
 (provide 'ivy)


### PR DESCRIPTION
This PR does several things.

- closes #33 . As describe in the issue, actions can now take an optional second argument that is a list of all marked candidates. To handle this, I decided to not call `prescient-remember` when multiple candidate have been marked. It could be very easy to mark 200 or so candidates and pollute your ratings.

- closes #28 . The issue was that the actions from counsel-find-file are full file paths, but the candidates are only the base name. Therefore the database didn't match the candidate list. I remove the directory name before we remember the candidate to address this.

- closes #27 and #24 . Use regexp in the default filter as discussed in that issue and removes the literal toggle.

Also I changed the action wrapper to only remember candidates when the collection is being sorted with ivy-prescient. This removes the need for `ivy-prescient-exclude-commands`.

Let me know what you think. Once everything is finalized, I will add a change log entry.

closes #15.