### PR TITLE
Allow ivy-prescient to remember directories used in navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The format is based on [Keep a Changelog].
   regexp is valid again. This behavior is more consistent and
   predictable.
 
+* Previously, ivy-prescient would only remember directories that the
+  user operated on with an action (for example, if you open it with
+  dired). Now it will remember all directories used in navigation.
+
 ### Bugs fixed
 * Fixed sorting in filename-based collections ([#28]).
 * Fixed an issue where Ivy actions that accepted a list of candidates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,10 @@ The format is based on [Keep a Changelog].
   candidate list would not update. Now, the list is cleared until your
   regexp is valid again. This behavior is more consistent and
   predictable.
-
-* Previously, ivy-prescient would only remember directories that the
-  user operated on with an action (for example, if you open it with
-  dired). Now it will remember all directories used in navigation.
+* Previously, `ivy-prescient.el` would only remember directories that
+  the user operated on with an action (for example, opening them with
+  Dired). Now it will remember all intermediate directories used in
+  navigation.
 
 ### Bugs fixed
 * Fixed sorting in filename-based collections ([#28]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog].
 * Previously, `ivy-prescient.el` would only remember directories that
   the user operated on with an action (for example, opening them with
   Dired). Now it will remember all intermediate directories used in
-  navigation.
+  navigation ([#36]).
 
 ### Bugs fixed
 * Fixed sorting in filename-based collections ([#28]).
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog].
 [#29]: https://github.com/raxod502/prescient.el/issues/29
 [#32]: https://github.com/raxod502/prescient.el/issues/32
 [#33]: https://github.com/raxod502/prescient.el/issues/33
+[#36]: https://github.com/raxod502/prescient.el/pull/36
 
 ## 2.2.2 (released 2019-02-12)
 ### Enhancements

--- a/ivy-prescient.el
+++ b/ivy-prescient.el
@@ -143,6 +143,15 @@ that also invokes `prescient-remember'."
           (prescient-remember cand))
         (funcall action x)))))
 
+(defun ivy-prescient--remember-directory (success)
+  "Remember the directory we just entered when SUCCESS."
+  (when success
+    (prescient-remember
+     (file-name-as-directory
+      (file-name-nondirectory
+       (directory-file-name ivy--directory)))))
+  success)
+
 (defun ivy-prescient--enable-sort-commands (args)
   "Enable sorting of `ivy-prescient-sort-commands'.
 If the `:caller' in ARGS is a member of
@@ -176,6 +185,8 @@ enabled."
                      #'ivy-prescient-sort-function)
           (advice-add #'ivy-read :filter-args
                       #'ivy-prescient--enable-sort-commands)
+          (advice-add #'ivy--directory-enter :filter-return
+                      #'ivy-prescient--remember-directory)
           (advice-add #'ivy--get-action :filter-return
                       #'ivy-prescient--wrap-action)))
     (when (equal (alist-get t ivy-re-builders-alist)
@@ -195,6 +206,7 @@ enabled."
       (dolist (pair (reverse ivy-prescient--old-initial-inputs-alist))
         (setf (alist-get (car pair) ivy-initial-inputs-alist) (cdr pair))))
     (advice-remove #'ivy-read #'ivy-prescient--enable-sort-commands)
+    (advice-remove #'ivy--directory-enter #'ivy-prescient--remember-directory)
     (advice-remove #'ivy--get-action #'ivy-prescient--wrap-action)))
 
 ;;;; Closing remarks

--- a/stub/ivy.el
+++ b/stub/ivy.el
@@ -14,5 +14,6 @@
 (defun ivy-state-collection (struct))
 (defun ivy--sort-function (collection))
 (defun ivy--get-action (collection))
+(defun ivy--directory-enter ())
 
 (provide 'ivy)


### PR DESCRIPTION
Currently, Ivy-prescient only remembers directories when they are part of an explicit action. However this means it provides no help when navigating a directory structure. This change makes it remember all directories even when they don't exit the ivy session and makes it more consistent. Let me know what you think.