### PR TITLE
Match first occurrence of characters in fuzzy search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
 ## Unreleased
+### Enhancements
+* The `fuzzy` regex builder now matches the first occurrence of each
+  character in the query, giving more intuitive results when
+  highlighted ([#37]).
+
+[#37]: https://github.com/raxod502/prescient.el/pull/37
+
 ### Bugs fixed
 * Logic error which caused a crash on an all-whitespace query has now
   been fixed.

--- a/prescient.el
+++ b/prescient.el
@@ -282,6 +282,30 @@ capture groups matching \"f\" and \"a\"."
              query
              "\\W*"))
 
+(defun prescient--fuzzy-regexp (query &optional with-groups)
+  "Return a regexp for fuzzy-matching QUERY.
+This means that the regexp will only match a given string if
+all characters in QUERY are present anywhere in the string in
+the specified order.
+
+If WITH-GROUPS is non-nil, enclose the parts of the regexp that
+match the QUERY characters in capture groups, so that the match
+data can be used to highlight the matched substrings."
+  (let ((chars (string-to-list query)))
+    (concat
+     (prescient--with-group
+      (regexp-quote
+       (char-to-string (car chars)))
+      with-groups)
+     (mapconcat
+      (lambda (char)
+        (format "[^%c\n]*%s" char
+                (prescient--with-group
+                 (regexp-quote
+                  (char-to-string char))
+                 with-groups)))
+      (cdr chars) ""))))
+
 ;; Remove this and do not document further changes in CHANGELOG after
 ;; six months or two releases, whichever comes later.
 (define-obsolete-function-alias
@@ -319,13 +343,7 @@ enclose literal substrings with capture groups."
                (string-match-p subquery "")
                subquery))
             (`fuzzy
-             (mapconcat
-              (lambda (char)
-                (prescient--with-group
-                 (regexp-quote
-                  (char-to-string char))
-                 with-groups))
-              subquery ".*"))))
+             (prescient--fuzzy-regexp subquery with-groups))))
         (pcase prescient-filter-method
           ;; We support `literal+initialism' for backwards
           ;; compatibility.


### PR DESCRIPTION
This gives more intuitive results when highlighting matches, matching the first occurrence of a character instead of the last.