### PR TITLE
Add prescient-aggressive-file-save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## 3.3 (released 2019-07-10)
+### Enhancements
+* New user option `prescient-aggressive-file-save` to enable
+  saving the cache data more aggressively according to the
+  discussions ([#17] and [#39]).
+
+[#17]: https://github.com/raxod502/prescient.el/issues/17
+[#39]: https://github.com/raxod502/prescient.el/pull/39
+
 ## 3.2 (released 2019-07-06)
 ### New features
 * New user options `prescient-sort-length-enable` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
-## 3.3 (released 2019-07-10)
+## Unreleased
 ### Enhancements
 * New user option `prescient-aggressive-file-save` to enable
   saving the cache data more aggressively according to the

--- a/prescient.el
+++ b/prescient.el
@@ -123,6 +123,13 @@ usefully be sorted by length (presumably, the backend returns
 these results in some already-sorted order)."
   :type 'boolean)
 
+(defcustom prescient-aggressive-file-save nil
+  "Whether to save the cache file aggressively.
+If non-nil, then write the cache data to `prescient-save-file'
+after the cache data is updated by `prescient-remember' when
+`prescient-persist-mode' is activated."
+  :type 'boolean)
+
 ;;;; Caches
 
 (defvar prescient--history (make-hash-table :test 'equal)
@@ -457,7 +464,11 @@ Return the sorted list. The original is modified destructively."
                  (puthash cand new-freq prescient--frequency))))
            prescient--frequency)
   ;; Update serial number.
-  (cl-incf prescient--serial-number))
+  (cl-incf prescient--serial-number)
+  ;; Save the cache data.
+  (when (and prescient-persist-mode
+	     prescient-aggressive-file-save)
+    (prescient--save)))
 
 ;;;; Closing remarks
 


### PR DESCRIPTION
Hi!

I have checked the discussion on `prescient--save` (https://github.com/raxod502/prescient.el/issues/17), and I agree to the idea on the additional implementation for the functionality to save the cache data more frequently because some users will not kill Emacs frequently if they use emacsclient.

So I suggest to add a new flag to control the frequency so that the cache can be saved when any commands are executed.

In my PR, since the value of `prescient-aggressive-file-save` is `nil` so nothing will be happened, but if user specifies `t` to the flag, then `prescient-save` will be called after executing `prescient-remember`.

I'd be glad if you check the proposed code. Thanks.

Best,
Takaaki