### PR TITLE
Clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ different one by customizing `prescient-filter-method`.
   candidates. You can override this preference and re-enable sorting
   by adding such commands here. (To check if a command disables
   sorting, inspect its source code and see if it calls `ivy-read` with
-  a nil value for the `:sort` keyword argument.)
+  a nil value for the `:sort` keyword argument. If `:sort` is not configured in `ivy-read`, then it also means sorting is disabled.)
 
 * `ivy-prescient-retain-classic-highlighting`: By default, the
   highlighting behavior of `ivy-prescient.el` is slightly different

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ different one by customizing `prescient-filter-method`.
   candidates. You can override this preference and re-enable sorting
   by adding such commands here. (To check if a command disables
   sorting, inspect its source code and see if it calls `ivy-read` with
-  a nil value for the `:sort` keyword argument. If `:sort` is not configured in `ivy-read`, then it also means sorting is disabled.)
+  a nil value for the `:sort` keyword argument. If `:sort` is not
+  configured in `ivy-read`, then it also means sorting is disabled.)
 
 * `ivy-prescient-retain-classic-highlighting`: By default, the
   highlighting behavior of `ivy-prescient.el` is slightly different


### PR DESCRIPTION
Hi.

I propose adding a new sentence in README so that a new user can identify more easily which function should actually be included to `ivy-prescient-sort-commands`. Any comments on this? If you don't like this change, then just reject this PR.