### PR TITLE
support char folding in literal filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ The format is based on [Keep a Changelog].
   `find-function-at-point`, and other similarly named symbols. One
   difference is that you can't use `*` as a wildcard (it is instead
   taken literally), since you can achieve the same effect by
-  separating queries with a space.
+  separating queries with a space. See [#67].
 * Literal matching now supports char folding making Unicode text
-  filtering much easier.
+  filtering much easier ([#66]).
+
+[#66]: https://github.com/raxod502/prescient.el/pull/66
+[#67]: https://github.com/raxod502/prescient.el/pull/67
 
 ## 5.0 (release 2020-07-16)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,8 @@ The format is based on [Keep a Changelog].
   difference is that you can't use `*` as a wildcard (it is instead
   taken literally), since you can achieve the same effect by
   separating queries with a space.
-* Literal matching now supports char folding when
-  `search-default-mode` is set to `char-fold-to-regexp`. This makes
-  filtering of Unicode text easier.
+* Literal matching now supports char folding making Unicode text
+  filtering much easier.
 
 ## 5.0 (release 2020-07-16)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog].
   difference is that you can't use `*` as a wildcard (it is instead
   taken literally), since you can achieve the same effect by
   separating queries with a space.
+* Literal matching now supports char folding when
+  `search-default-mode` is set to `char-fold-to-regexp`. This makes
+  filtering of Unicode text easier.
 
 ## 5.0 (release 2020-07-16)
 ### Breaking changes

--- a/prescient.el
+++ b/prescient.el
@@ -87,8 +87,7 @@ using each subquery in turn. This variable affects how that
 filtering takes place.
 
 Value `literal' means the subquery must be a substring of the
-candidate. Supports char folding when `search-default-mode' is
-set to `char-fold-to-regexp'.
+candidate. Supports char folding.
 
 Value `regexp' means the subquery is interpreted directly as a
 regular expression.
@@ -388,9 +387,7 @@ enclose literal substrings with capture groups."
           (pcase method
             (`literal
              (prescient--with-group
-              (if (eq search-default-mode #'char-fold-to-regexp)
-                  (char-fold-to-regexp (regexp-quote subquery))
-                (regexp-quote subquery))
+              (char-fold-to-regexp subquery)
               (eq with-groups 'all)))
             (`initialism
              (prescient--initials-regexp subquery with-groups))

--- a/prescient.el
+++ b/prescient.el
@@ -87,7 +87,8 @@ using each subquery in turn. This variable affects how that
 filtering takes place.
 
 Value `literal' means the subquery must be a substring of the
-candidate.
+candidate. Supports char folding when `search-default-mode' is
+set to `char-fold-to-regexp'.
 
 Value `regexp' means the subquery is interpreted directly as a
 regular expression.
@@ -387,7 +388,9 @@ enclose literal substrings with capture groups."
           (pcase method
             (`literal
              (prescient--with-group
-              (regexp-quote subquery)
+              (if (eq search-default-mode #'char-fold-to-regexp)
+                  (char-fold-to-regexp (regexp-quote subquery))
+                (regexp-quote subquery))
               (eq with-groups 'all)))
             (`initialism
              (prescient--initials-regexp subquery with-groups))


### PR DESCRIPTION
This change enables support of char folding in `literal` filter. Makes it so much easier to filter Unicode characters. 

For example, running the following code and typing `buna` in the mini-buffer matches both candidates if `search-default-mode` is set to `char-fold-to-regexp`. Otherwise only the last one would be matched.

```emacs-lisp
(completing-read
 "greeting: "
 '("Bună dimineața"
   "Buna dimineata"))
```

<img width="167" alt="image" src="https://user-images.githubusercontent.com/6507913/89222481-cbafb480-d5dd-11ea-990f-8c2f8d7fbaa6.png">

WDYT? 

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
