### PR TITLE
Add way to match prefixes, similar to `partial-completion`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### Enhancements
+* Prefix matching, similar to the completion style `partial`, has been
+  added. As is the case in default Emacs, `t-t-l` matches
+  `toggle-truncate-lines` and `fi--a-po` matches `find-file-at-point`,
+  `find-function-at-point`, and other similarly named symbols. One
+  difference is that you can't use `*` as equivalent to the regexp
+  `.*` (it is instead taken literally), since you can already achieve
+  the same affect by separating your queries with a space.
+
 ## 5.0 (release 2020-07-16)
 ### Breaking changes
 * Candidates which are not strings are no longer supported. This

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ The format is based on [Keep a Changelog].
 
 ## Unreleased
 ### Enhancements
-* Prefix matching, similar to the completion style `partial`, has been
-  added. As is the case in default Emacs, `t-t-l` matches
+* Prefix matching, a new filtering method similar to the Emacs
+  completion style `partial`, was added. It can be enabled by adding
+  `prefix` to `prescient-filter-method`.
+
+  As is the case in partial completion, `t-t-l` matches
   `toggle-truncate-lines` and `fi--a-po` matches `find-file-at-point`,
   `find-function-at-point`, and other similarly named symbols. One
-  difference is that you can't use `*` as equivalent to the regexp
-  `.*` (it is instead taken literally), since you can already achieve
-  the same affect by separating your queries with a space.
+  difference is that you can't use `*` as a wildcard (it is instead
+  taken literally), since you can achieve the same effect by
+  separating queries with a space.
 
 ## 5.0 (release 2020-07-16)
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ different one by customizing `prescient-filter-method`.
 * `prescient-filter-method`: A list of algorithms to use for filtering
   candidates. The default is `literal`, `regexp`, and `initialism` as
   described above, but you can also use substring matching, initialism
-  matching, regexp matching, fuzzy matching, or any combination of
-  those. See the docstring for full details.
+  matching, regexp matching, fuzzy matching, prefix matching, or any
+  combination of those. See the docstring for full details.
 
 * `ivy-prescient-sort-commands`: By default, all commands have their
   candidates sorted. You can override this behavior by customizing

--- a/prescient.el
+++ b/prescient.el
@@ -352,28 +352,17 @@ data can be used to highlight the matched substrings.
 E.g., \"fi--a-po\" matches \"find-file-at-point\",
 \"find-function-at-point\", and other similarly named symbols."
 
-  (prescient--with-group
-   (save-match-data
-     (let ((start 0)
-           (replacement))
-       ;; In order to escape the non-word separator characters with
-       ;; `regexp-quote' (important for matching "."), we search
-       ;; progressively through the query.
-       (while (string-match "[^[:word:]]" query start)
-         (setq replacement (concat "[[:word:]]+?"
-                                   (regexp-quote (match-string 0 query))))
-         ;; Some separators will need to be escape while others won't,
-         ;; so the length of the replacement can be different in
-         ;; different cases.
-         (setq start (+ (- (length replacement)
-                           (length (match-string 0 query)))
-                        (match-end 0)))
-         ;; Since we're escaping the separators, we need to make
-         ;; the replacements literal.  Otherwise, this will fail.
-         (setq query (replace-match replacement nil t query)))
-       ;; Make sure that regexp begins at start of word.
-       (concat "\\<" query)))
-   with-groups))
+  (when (string-match-p "[[:word:]][^[:word:]]" query)
+      (prescient--with-group
+       (concat "\\<"
+               (replace-regexp-in-string
+                "[^[:word:]]"
+                (lambda (s) (concat "[[:word:]]*" (regexp-quote s)))
+                query
+                ;; Since quoting the non-word character,
+                ;; must replace literally.
+                t t ))
+       with-groups)))
 
 ;;;; Sorting and filtering
 

--- a/prescient.el
+++ b/prescient.el
@@ -348,20 +348,24 @@ match the QUERY characters in capture groups, so that the match
 data can be used to highlight the matched substrings."
 
   (prescient--with-group
-              (save-match-data
-                (cl-loop with str = query
-                         with start = 0
-                         while (string-match "[^[:word:]]" str start)
-                         do (progn
-                              ;; (message "Start: %d\nString: %s" start str)
-                              (setq start (+ 11 (match-end 0)))
-                              (setq str (replace-match
-                                         (concat ;; "\\W+"
-                                          "[[:word:]]+"
-                                          (match-string 0 str))
-                                         nil t str)))
-                         finally return (concat "\\<" str)))
-              with-groups))
+   (save-match-data
+     (cl-loop with str = query
+              with start = 0
+              with replacement = ""
+              while (string-match "[^[:word:]]" str start)
+              do (progn
+                   (setq replacement (concat "[[:word:]]+"
+                                             (regexp-quote
+                                              (match-string 0 str))))
+                   (setq start (+ (- (length replacement)
+                                     (length (match-string 0 str)))
+                                  (match-end 0)))
+                   (setq str (replace-match
+                              (concat "[[:word:]]+"
+                                      (match-string 0 str))
+                              nil t str)))
+              finally return (concat "\\<" str)))
+   with-groups))
 ;;;; Sorting and filtering
 
 (defun prescient-filter-regexps (query &optional with-groups)

--- a/prescient.el
+++ b/prescient.el
@@ -360,7 +360,7 @@ E.g., \"fi--a-po\" matches \"find-file-at-point\",
        ;; `regexp-quote' (important for matching "."), we search
        ;; progressively through the query.
        (while (string-match "[^[:word:]]" query start)
-         (setq replacement (concat "[[:word:]]+"
+         (setq replacement (concat "[[:word:]]+?"
                                    (regexp-quote (match-string 0 query))))
          ;; Some separators will need to be escape while others won't,
          ;; so the length of the replacement can be different in

--- a/prescient.el
+++ b/prescient.el
@@ -99,6 +99,12 @@ Value `fuzzy' means the characters of the subquery must match
 some subset of those of the candidate, in the correct order but
 not necessarily contiguous.
 
+Value `prefix' means the words (substrings of only word
+characters) match the beginning of words found in the candidate,
+in order, separated by the same non-word characters that separate
+words in the query. This is similar to the completion style
+`partial'.
+
 Value can also be a list of any of the above methods, in which
 case each method will be applied in order until one matches.
 
@@ -109,7 +115,8 @@ be `literal+initialism', which equivalent to the list (`literal'
           (const :tag "Literal" literal)
           (const :tag "Regexp" regexp)
           (const :tag "Initialism" initialism)
-          (const :tag "Fuzzy" fuzzy)))
+          (const :tag "Fuzzy" fuzzy)
+          (const :tag "Prefix" prefix)))
 
 (defcustom prescient-sort-length-enable t
   "Whether to sort candidates by length.

--- a/prescient.el
+++ b/prescient.el
@@ -355,7 +355,6 @@ that case by separating queries with a space.
 If WITH-GROUPS is non-nil, enclose the parts of the regexp that
 match the QUERY characters in capture groups, so that the match
 data can be used to highlight the matched substrings."
-
   (when (string-match-p "[[:word:]][^[:word:]]" query)
       (prescient--with-group
        (concat "\\<"

--- a/prescient.el
+++ b/prescient.el
@@ -347,10 +347,7 @@ that case by separating queries with a space.
 
 If WITH-GROUPS is non-nil, enclose the parts of the regexp that
 match the QUERY characters in capture groups, so that the match
-data can be used to highlight the matched substrings.
-
-E.g., \"fi--a-po\" matches \"find-file-at-point\",
-\"find-function-at-point\", and other similarly named symbols."
+data can be used to highlight the matched substrings."
 
   (when (string-match-p "[[:word:]][^[:word:]]" query)
       (prescient--with-group

--- a/prescient.el
+++ b/prescient.el
@@ -371,7 +371,8 @@ E.g., \"fi--a-po\" matches \"find-file-at-point\",
          ;; Since we're escaping the separators, we need to make
          ;; the replacements literal.  Otherwise, this will fail.
          (setq query (replace-match replacement nil t query)))
-       query))
+       ;; Make sure that regexp begins at start of word.
+       (concat "\\<" query)))
    with-groups))
 
 ;;;; Sorting and filtering

--- a/prescient.el
+++ b/prescient.el
@@ -358,7 +358,7 @@ data can be used to highlight the matched substrings."
                 query
                 ;; Since quoting the non-word character,
                 ;; must replace literally.
-                t t ))
+                'fixed-case 'literal))
        with-groups)))
 
 ;;;; Sorting and filtering


### PR DESCRIPTION
This adds a filtering regexp similar to the `partial-completion` style provided by Emacs.

This is convenient when quickly editing history items to find something similarly named, or just when being used to this particular behavior in default Emacs.

For example, `t-t-l` matches `toggle-truncate-lines` (though I prefer using the `initialism` style in this case), and `fi--a-po` matches `find-file-at-point`, `find-function-at-point`, and other similarly named symbols.

What are your thoughts?