### PR TITLE
New anchored filter method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog].
 
 ## Unreleased
 ### Enhancements
+* Anchored matching, a new filtering method that uses uppercase
+  letters and symbols as beginning of word, similar to initialism.
+  It can be enabled by adding `anchored` to
+  `prescient-filter-method`.
+  
+  For example `TTL` matches `toogle-truncate-lines` and `FiAPo`
+  or `fiAPo` match both `find-file-at-point` and
+  `find-function-at-point`. However `fiFiAPo` matches only the former
+  and `fiFuAPo` matches only the latter. See [#70].
 * Prefix matching, a new filtering method similar to the Emacs
   completion style `partial`, was added. It can be enabled by adding
   `prefix` to `prescient-filter-method`.
@@ -20,6 +29,7 @@ The format is based on [Keep a Changelog].
 
 [#66]: https://github.com/raxod502/prescient.el/pull/66
 [#67]: https://github.com/raxod502/prescient.el/pull/67
+[#70]: https://github.com/raxod502/prescient.el/pull/70
 
 ## 5.0 (release 2020-07-16)
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ different one by customizing `prescient-filter-method`.
 * `prescient-filter-method`: A list of algorithms to use for filtering
   candidates. The default is `literal`, `regexp`, and `initialism` as
   described above, but you can also use substring matching, initialism
-  matching, regexp matching, fuzzy matching, prefix matching, or any
-  combination of those. See the docstring for full details.
+  matching, regexp matching, fuzzy matching, prefix matching, anchored
+  matching or any combination of those. See the docstring for full
+  details.
 
 * `ivy-prescient-sort-commands`: By default, all commands have their
   candidates sorted. You can override this behavior by customizing


### PR DESCRIPTION
# New `anchored` filter method

The proposed filter uses _uppercased_ letters and _symbols_ as anchors
 for word beginning.

For example, assuming the text "find-file-at-point":
- Query "FFP" matches "(f)ind-(f)ile-at-(p)oint"
- Query "FiPoint" matches "(fi)nd-file-at-(point)"
- Query "fiFAP" matches "(fi)nd-(f)ile-(a)t-(p)oint"
- Query "fi-a-p" matches "(fi)nd-file-(a)t-(p)oint"

The rationale for a new filter is that it has the convenience of `initialism`,
with more control to the user, but without increase the number of
keystrokes.
