### PR TITLE
For Selectrum, add commands that toggle filtering methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,13 @@ The format is based on [Keep a Changelog].
     `selectrum-prescient-filter-toggle-map`. The following toggle
     commands and their keys are:
 
-    | Key   | Command                               |
-    |-------|---------------------------------------|
-    | M-s f | selectrum-prescient-toggle-fuzzy      |
-    | M-s i | selectrum-prescient-toggle-initialism |
-    | M-s l | selectrum-prescient-toggle-literal    |
-    | M-s p | selectrum-prescient-toggle-prefix     |
-    | M-s r | selectrum-prescient-toggle-regexp     |
+    | Key   | Command                                 |
+    |-------|-----------------------------------------|
+    | M-s f | `selectrum-prescient-toggle-fuzzy`      |
+    | M-s i | `selectrum-prescient-toggle-initialism` |
+    | M-s l | `selectrum-prescient-toggle-literal`    |
+    | M-s p | `selectrum-prescient-toggle-prefix`     |
+    | M-s r | `selectrum-prescient-toggle-regexp`     |
 
 
 [#66]: https://github.com/raxod502/prescient.el/pull/66

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,12 +37,12 @@ The format is based on [Keep a Changelog].
 
     | Key   | Command                                 |
     |-------|-----------------------------------------|
+    | M-s a | `selectrum-prescient-toggle-anchored`   |
     | M-s f | `selectrum-prescient-toggle-fuzzy`      |
     | M-s i | `selectrum-prescient-toggle-initialism` |
     | M-s l | `selectrum-prescient-toggle-literal`    |
     | M-s p | `selectrum-prescient-toggle-prefix`     |
     | M-s r | `selectrum-prescient-toggle-regexp`     |
-
 
 [#66]: https://github.com/raxod502/prescient.el/pull/66
 [#67]: https://github.com/raxod502/prescient.el/pull/67

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ The format is based on [Keep a Changelog].
   separating queries with a space. See [#67].
 * Literal matching now supports char folding making Unicode text
   filtering much easier ([#66]).
+* For Selectrum, commands were added to toggle filter methods for the
+  running Selectrum buffer. This toggling does not change the default
+  filter settings determined by `prescient-filter-method`. You can use
+  a prefix argument to disable other filtering methods.
+  * In `selectrum-minibuffer-map`, `M-s` is now bound to
+    `selectrum-prescient-filter-toggle-map`. The following toggle
+    commands and their keys are as follows:
+
+    | Key   | Command                               |
+    |-------|---------------------------------------|
+    | M-s f | selectrum-prescient-toggle-fuzzy      |
+    | M-s i | selectrum-prescient-toggle-initialism |
+    | M-s l | selectrum-prescient-toggle-literal    |
+    | M-s p | selectrum-prescient-toggle-prefix     |
+    | M-s r | selectrum-prescient-toggle-regexp     |
+
 
 [#66]: https://github.com/raxod502/prescient.el/pull/66
 [#67]: https://github.com/raxod502/prescient.el/pull/67

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,14 +35,14 @@ The format is based on [Keep a Changelog].
     `selectrum-prescient-toggle-map`. The toggling commands and their
     keys bindings are:
 
-    | Key   | Command                                 |
-    |-------|-----------------------------------------|
-    | M-s a | `selectrum-prescient-toggle-anchored`   |
-    | M-s f | `selectrum-prescient-toggle-fuzzy`      |
-    | M-s i | `selectrum-prescient-toggle-initialism` |
-    | M-s l | `selectrum-prescient-toggle-literal`    |
-    | M-s p | `selectrum-prescient-toggle-prefix`     |
-    | M-s r | `selectrum-prescient-toggle-regexp`     |
+    | Key     | Command                                 |
+    |---------|-----------------------------------------|
+    | `M-s a` | `selectrum-prescient-toggle-anchored`   |
+    | `M-s f` | `selectrum-prescient-toggle-fuzzy`      |
+    | `M-s i` | `selectrum-prescient-toggle-initialism` |
+    | `M-s l` | `selectrum-prescient-toggle-literal`    |
+    | `M-s p` | `selectrum-prescient-toggle-prefix`     |
+    | `M-s r` | `selectrum-prescient-toggle-regexp`     |
 
 [#66]: https://github.com/raxod502/prescient.el/pull/66
 [#67]: https://github.com/raxod502/prescient.el/pull/67

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog].
 * For Selectrum, commands were added to toggle filter methods for the
   running Selectrum buffer. This toggling does not change the default
   filter settings determined by `prescient-filter-method`. You can use
-  a prefix argument to disable other filtering methods.
+  a prefix argument to disable other filtering methods. See [#72].
   * In `selectrum-minibuffer-map`, `M-s` is now bound to
     `selectrum-prescient-filter-toggle-map`. The following toggle
     commands and their keys are as follows:
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog].
 
 [#66]: https://github.com/raxod502/prescient.el/pull/66
 [#67]: https://github.com/raxod502/prescient.el/pull/67
+[#72]: https://github.com/raxod502/prescient.el/pull/72
 
 ## 5.0 (release 2020-07-16)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,8 @@ The format is based on [Keep a Changelog].
   can use a prefix argument to use only the filtering method
   associated with that command. See [#72].
   * In `selectrum-minibuffer-map`, `M-s` is now bound to
-    `selectrum-prescient-toggle-map`. The following toggle commands
-    and their keys are:
+    `selectrum-prescient-toggle-map`. The toggling commands and their
+    keys bindings are:
 
     | Key   | Command                                 |
     |-------|-----------------------------------------|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,14 +26,15 @@ The format is based on [Keep a Changelog].
   separating queries with a space. See [#67].
 * Literal matching now supports char folding making Unicode text
   filtering much easier ([#66]).
-* For Selectrum, commands were added to toggle filtering methods for
-  the running Selectrum buffer. This toggling does not change the
-  default filter settings determined by `prescient-filter-method`. You
-  can use a prefix argument to use only the filtering method
-  associated with that command. See [#72].
-  * In `selectrum-minibuffer-map`, `M-s` is now bound to
-    `selectrum-prescient-toggle-map`. The toggling commands and their
-    keys bindings are:
+* In `selectrum-prescient.el`, commands were added for toggling the
+  active filtering methods in the Selectrum buffer. See [#72].
+  * This toggling is a buffer-local effect, and does not change the
+    default filter settings determined by `prescient-filter-method`.
+  * With a prefix argument, a command unconditionally toggles on its
+    respective filtering method and toggles off all others.
+  * While `selectrum-prescient-mode` is enabled, `M-s` is bound to
+    `selectrum-prescient-toggle-map` in the Selectrum buffer, and is
+    used as a prefix key to access the commands.
 
     | Key     | Command                                 |
     |---------|-----------------------------------------|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,14 @@ The format is based on [Keep a Changelog].
   separating queries with a space. See [#67].
 * Literal matching now supports char folding making Unicode text
   filtering much easier ([#66]).
-* For Selectrum, commands were added to toggle filter methods for the
-  running Selectrum buffer. This toggling does not change the default
-  filter settings determined by `prescient-filter-method`. You can use
-  a prefix argument to disable other filtering methods. See [#72].
+* For Selectrum, commands were added to toggle filtering methods for
+  the running Selectrum buffer. This toggling does not change the
+  default filter settings determined by `prescient-filter-method`. You
+  can use a prefix argument to use only the filtering method
+  associated with that command. See [#72].
   * In `selectrum-minibuffer-map`, `M-s` is now bound to
     `selectrum-prescient-filter-toggle-map`. The following toggle
-    commands and their keys are as follows:
+    commands and their keys are:
 
     | Key   | Command                               |
     |-------|---------------------------------------|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,8 @@ The format is based on [Keep a Changelog].
   can use a prefix argument to use only the filtering method
   associated with that command. See [#72].
   * In `selectrum-minibuffer-map`, `M-s` is now bound to
-    `selectrum-prescient-filter-toggle-map`. The following toggle
-    commands and their keys are:
+    `selectrum-prescient-toggle-map`. The following toggle commands
+    and their keys are:
 
     | Key   | Command                                 |
     |-------|-----------------------------------------|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ The format is based on [Keep a Changelog].
   filtering much easier ([#66]).
 * In `selectrum-prescient.el`, commands were added for toggling the
   active filtering methods in the Selectrum buffer. See [#72].
-  * This toggling is a buffer-local effect, and does not change the
-    default filter settings determined by `prescient-filter-method`.
+  * This toggling is a buffer-local effect, and doesn't change the
+    default behavior (determined by `prescient-filter-method`).
   * With a prefix argument, a command unconditionally toggles on its
     respective filtering method and toggles off all others.
   * While `selectrum-prescient-mode` is enabled, `M-s` is bound to

--- a/README.md
+++ b/README.md
@@ -131,9 +131,8 @@ the default filter settings. For that, customize
 These commands are similar to Isearch's own toggling commands in
 usage, except that multiple filtering methods can be active at the
 same time. In the Selectrum buffer, `M-s` is bound to
-`selectrum-prescient-filter-toggle-map` when
-`selectrum-prescient-mode` is active, and is used as a prefix key to
-access the commands.
+`selectrum-prescient-toggle-map` when `selectrum-prescient-mode` is
+active, and is used as a prefix key to access the commands.
 
 | Key   | Command                                 |
 |-------|-----------------------------------------|

--- a/README.md
+++ b/README.md
@@ -116,19 +116,24 @@ Ivy:
   and how to customize it manually.
 
 ### Selectrum-specific
-For Selectrum, you can use special commands to toggle the current
-filters that you are using. For example, to toggle regexp filtering on
-or off (perhaps you're searching for a long/complex candidate), you
-can press `M-s r`. If you wish to use *only* regexp filtering, you can
-use `C-u M-s r` to unconditionally turn on regexp filtering and turn
-off all other methods.
+`selectrum-prescient.el` provides special commands (see the table
+below) to adjust how `prescient.el` filters candidates in the current
+Selectrum buffer.
 
-These commands can be found in
-`selectrum-prescient-filter-toggle-map`,
-which is bound to `M-s` inside the Selectrum buffer. This is similar
-to Isearch's own toggling commands (such as
-`isearch-toggle-char-fold`, bound to `M-s '`), except that multiple
-filtering methods can be active at the same time.
+For example, to toggle regexp filtering on or off (perhaps you're
+searching for a long/complex candidate), you can press `M-s r`. If you
+wish to use *only* regexp filtering, you can use `C-u M-s r` to
+unconditionally turn on regexp filtering and turn off all other
+methods. This toggling is a buffer-local effect, and does not change
+the default filter settings. For that, customize
+`prescient-filter-method`.
+
+These commands are similar to Isearch's own toggling commands in
+usage, except that multiple filtering methods can be active at the
+same time. In the Selectrum buffer, `M-s` is bound to
+`selectrum-prescient-filter-toggle-map` when
+`selectrum-prescient-mode` is active, and is used as a prefix key to
+access the commands.
 
 | Key   | Command                                 |
 |-------|-----------------------------------------|
@@ -138,10 +143,6 @@ filtering methods can be active at the same time.
 | M-s l | `selectrum-prescient-toggle-literal`    |
 | M-s p | `selectrum-prescient-toggle-prefix`     |
 | M-s r | `selectrum-prescient-toggle-regexp`     |
-
-These commands only affect the current Selectrum buffer, not the
-default filter settings. To permanently change your filter settings,
-you should customize `prescient-filter-method`.
 
 ## Contributor guide
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ ones, and then the remaining candidates are sorted by length. If you
 don't like the algorithm used for filtering, you can choose a
 different one by customizing `prescient-filter-method`.
 
-## Configuration
+## Configuration and Other Features
 
 * `prescient-history-length`: The number of recently selected
   candidates that are remembered and displayed at the top of the list.
@@ -114,11 +114,19 @@ The following user options are specific to using Prescient with Ivy:
   and how to customize it manually.
 
 ### Selectrum-Specific
-In Selectrum, commands for toggling the filter methods used are bound
-to a `M-s` prefix. This is similar to toggling commands used with
-Isearch, such as `isearch-toggle-char-fold`, which is bound to `M-s '`
-in `isearch-mode-map`. These Selectrum commands are bound in
-`selectrum-prescient-filter-toggle-map`, and are:
+For Selectrum, you can use special commands to toggle the current
+filters that you are using. For example, to toggle regexp filtering
+filtering on or off (perhaps you're searching for a long/complex
+candidate), you can press `M-s r`. If you wish to use *only* regexp
+filtering, you can use `C-u M-s r` to unconditionally turn on regexp
+filtering and turn off all other methods.
+
+These commands can be found in
+`selectrum-prescient-filter-toggle-map`,
+which is bound to `M-s` inside the Selectrum buffer. This is similar
+to Isearch's own toggling commands (such as
+`isearch-toggle-char-fold`, bound to `M-s '`), except that multiple
+filtering methods can be active at the same time.
 
 | Key   | Command                               |
 |-------|---------------------------------------|
@@ -128,15 +136,9 @@ in `isearch-mode-map`. These Selectrum commands are bound in
 | M-s p | selectrum-prescient-toggle-prefix     |
 | M-s r | selectrum-prescient-toggle-regexp     |
 
-For example, if you wish to disable regexp filtering while inputting
-a complex string (maybe to search for it literally), you can press
-`M-s r` to toggle whether Selectrum uses Prescient's regexp
-filtering. If you wish to use *only* regexp filtering, you can use
-`C-u M-s r` to temporarily disable all other filter methods.
-
-This toggling only applies to the current Selectrum buffer, and
-doesn't affect the default filter settings (determined by
-`prescient-filter-method`).
+These commands only affect the current Selectrum buffer, not the
+default filter settings. To permanently change your filter settings,
+you should customize `prescient-filter-method`.
 
 ## Contributor guide
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ different one by customizing `prescient-filter-method`.
   matching, regexp matching, fuzzy matching, prefix matching, or any
   combination of those. See the docstring for full details.
 
+### Ivy-Specific
+The following user options are specific to using Prescient with Ivy:
+
 * `ivy-prescient-sort-commands`: By default, all commands have their
   candidates sorted. You can override this behavior by customizing
   `ivy-prescient-sort-commands`. See the docstring.
@@ -109,6 +112,31 @@ different one by customizing `prescient-filter-method`.
   `ivy-prescient.el` does not apply `prescient.el` sorting to Ivy. See
   the Ivy documentation for information on how Ivy sorts by default,
   and how to customize it manually.
+
+### Selectrum-Specific
+In Selectrum, commands for toggling the filter methods used are bound
+to a `M-s` prefix. This is similar to toggling commands used with
+Isearch, such as `isearch-toggle-char-fold`, which is bound to `M-s '`
+in `isearch-mode-map`. These Selectrum commands are bound in
+`selectrum-prescient-filter-toggle-map`, and are:
+
+| Key   | Command                               |
+|-------|---------------------------------------|
+| M-s f | selectrum-prescient-toggle-fuzzy      |
+| M-s i | selectrum-prescient-toggle-initialism |
+| M-s l | selectrum-prescient-toggle-literal    |
+| M-s p | selectrum-prescient-toggle-prefix     |
+| M-s r | selectrum-prescient-toggle-regexp     |
+
+For example, if you wish to disable regexp filtering while inputting
+a complex string (maybe to search for it literally), you can press
+`M-s r` to toggle whether Selectrum uses Prescient's regexp
+filtering. If you wish to use *only* regexp filtering, you can use
+`C-u M-s r` to temporarily disable all other filter methods.
+
+This toggling only applies to the current Selectrum buffer, and
+doesn't affect the default filter settings (determined by
+`prescient-filter-method`).
 
 ## Contributor guide
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ searching for a long/complex candidate), you can press `M-s r`. If you
 wish to use *only* regexp filtering, you can use `C-u M-s r` to
 unconditionally turn on regexp filtering and turn off all other
 methods. This toggling is a buffer-local effect, and does not change
-the default filter settings. For that, customize
+the default filter behavior. For that, customize
 `prescient-filter-method`.
 
 These commands are similar in usage to Isearch's own toggling

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ The following user options are specific to using Prescient with Ivy:
 
 ### Selectrum-Specific
 For Selectrum, you can use special commands to toggle the current
-filters that you are using. For example, to toggle regexp filtering
-filtering on or off (perhaps you're searching for a long/complex
-candidate), you can press `M-s r`. If you wish to use *only* regexp
-filtering, you can use `C-u M-s r` to unconditionally turn on regexp
-filtering and turn off all other methods.
+filters that you are using. For example, to toggle regexp filtering on
+or off (perhaps you're searching for a long/complex candidate), you
+can press `M-s r`. If you wish to use *only* regexp filtering, you can
+use `C-u M-s r` to unconditionally turn on regexp filtering and turn
+off all other methods.
 
 These commands can be found in
 `selectrum-prescient-filter-toggle-map`,

--- a/README.md
+++ b/README.md
@@ -134,14 +134,14 @@ same time. While `selectrum-prescient-mode` is enabled, `M-s` is bound
 to `selectrum-prescient-toggle-map` in the Selectrum buffer, and is
 used as a prefix key to access the commands.
 
-| Key   | Command                                 |
-|-------|-----------------------------------------|
-| M-s a | `selectrum-prescient-toggle-anchored`   |
-| M-s f | `selectrum-prescient-toggle-fuzzy`      |
-| M-s i | `selectrum-prescient-toggle-initialism` |
-| M-s l | `selectrum-prescient-toggle-literal`    |
-| M-s p | `selectrum-prescient-toggle-prefix`     |
-| M-s r | `selectrum-prescient-toggle-regexp`     |
+| Key     | Command                                 |
+|---------|-----------------------------------------|
+| `M-s a` | `selectrum-prescient-toggle-anchored`   |
+| `M-s f` | `selectrum-prescient-toggle-fuzzy`      |
+| `M-s i` | `selectrum-prescient-toggle-initialism` |
+| `M-s l` | `selectrum-prescient-toggle-literal`    |
+| `M-s p` | `selectrum-prescient-toggle-prefix`     |
+| `M-s r` | `selectrum-prescient-toggle-regexp`     |
 
 ## Contributor guide
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ ones, and then the remaining candidates are sorted by length. If you
 don't like the algorithm used for filtering, you can choose a
 different one by customizing `prescient-filter-method`.
 
-## Configuration and Other Features
+## Configuration and other features
 
 * `prescient-history-length`: The number of recently selected
   candidates that are remembered and displayed at the top of the list.
@@ -90,7 +90,7 @@ different one by customizing `prescient-filter-method`.
   matching, regexp matching, fuzzy matching, prefix matching, or any
   combination of those. See the docstring for full details.
 
-### Ivy-Specific
+### Ivy-specific
 The following user options are specific to using Prescient with Ivy:
 
 * `ivy-prescient-sort-commands`: By default, all commands have their
@@ -113,7 +113,7 @@ The following user options are specific to using Prescient with Ivy:
   the Ivy documentation for information on how Ivy sorts by default,
   and how to customize it manually.
 
-### Selectrum-Specific
+### Selectrum-specific
 For Selectrum, you can use special commands to toggle the current
 filters that you are using. For example, to toggle regexp filtering on
 or off (perhaps you're searching for a long/complex candidate), you

--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ to Isearch's own toggling commands (such as
 `isearch-toggle-char-fold`, bound to `M-s '`), except that multiple
 filtering methods can be active at the same time.
 
-| Key   | Command                               |
-|-------|---------------------------------------|
-| M-s f | selectrum-prescient-toggle-fuzzy      |
-| M-s i | selectrum-prescient-toggle-initialism |
-| M-s l | selectrum-prescient-toggle-literal    |
-| M-s p | selectrum-prescient-toggle-prefix     |
-| M-s r | selectrum-prescient-toggle-regexp     |
+| Key   | Command                                 |
+|-------|-----------------------------------------|
+| M-s f | `selectrum-prescient-toggle-fuzzy`      |
+| M-s i | `selectrum-prescient-toggle-initialism` |
+| M-s l | `selectrum-prescient-toggle-literal`    |
+| M-s p | `selectrum-prescient-toggle-prefix`     |
+| M-s r | `selectrum-prescient-toggle-regexp`     |
 
 These commands only affect the current Selectrum buffer, not the
 default filter settings. To permanently change your filter settings,

--- a/README.md
+++ b/README.md
@@ -128,11 +128,11 @@ methods. This toggling is a buffer-local effect, and does not change
 the default filter settings. For that, customize
 `prescient-filter-method`.
 
-These commands are similar to Isearch's own toggling commands in
-usage, except that multiple filtering methods can be active at the
-same time. In the Selectrum buffer, `M-s` is bound to
-`selectrum-prescient-toggle-map` when `selectrum-prescient-mode` is
-active, and is used as a prefix key to access the commands.
+These commands are similar in usage to Isearch's own toggling
+commands, except that multiple filtering methods can be active at the
+same time. While `selectrum-prescient-mode` is enabled, `M-s` is bound
+to `selectrum-prescient-toggle-map` in the Selectrum buffer, and is
+used as a prefix key to access the commands.
 
 | Key   | Command                                 |
 |-------|-----------------------------------------|

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ filtering methods can be active at the same time.
 
 | Key   | Command                                 |
 |-------|-----------------------------------------|
+| M-s a | `selectrum-prescient-toggle-anchored`   |
 | M-s f | `selectrum-prescient-toggle-fuzzy`      |
 | M-s i | `selectrum-prescient-toggle-initialism` |
 | M-s l | `selectrum-prescient-toggle-literal`    |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ different one by customizing `prescient-filter-method`.
   combination of those. See the docstring for full details.
 
 ### Ivy-specific
-The following user options are specific to using Prescient with Ivy:
+The following user options are specific to using `prescient.el` with
+Ivy:
 
 * `ivy-prescient-sort-commands`: By default, all commands have their
   candidates sorted. You can override this behavior by customizing

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -111,8 +111,8 @@ passed to `kbd', whose output will be bound in
              (setq prescient-filter-method '(,filter-type))
 
            ;; Otherwise, if we need to add or remove from the list,
-           ;; make sure it's actually a list.
-           (when (nlistp prescient-filter-method)
+           ;; make sure it's actually a list and not just a symbol.
+           (when (symbolp prescient-filter-method)
              (setq prescient-filter-method
                    (list prescient-filter-method)))
 

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -76,13 +76,16 @@ For use on `selectrum-candidate-selected-hook'."
 ;;;;; Toggling Commands
 (defvar selectrum-prescient-toggle-map (make-sparse-keymap)
   "A keymap of commands for toggling Prescient filters in Selectrum.
-The toggling of commands is temporary and does not affect the
-default filtering settings determined by `prescient-filter-method'.")
-;; Create a binding similar to the Isearch toggles.
+Such commands are created and automatically bound in this map by
+`selectrum--prescient-create-and-bind-toggle-command'.")
 
 (defmacro selectrum--prescient-create-and-bind-toggle-command
     (filter-type key-string)
-  "Create and bind a command to toggle the use of FILTER-TYPE in Selectrum.
+  "Create and bind a command to toggle the use of a filter method in Selectrum.
+
+The created command toggles the FILTER-TYPE algorithm on or off
+buffer-locally, and doesn't affect the default
+behavior (determined by `prescient-filter-method').
 
 FILTER-TYPE is an unquoted symbol that can be used in
 `prescient-filter-method'.  KEY-STRING is a string that can be
@@ -96,13 +99,15 @@ passed to `kbd', whose output will be bound in
                                filter-type-name))
            (arg) ; Arg list
          ,(format
-           "Toggle the \"%s\" filter. With ARG, use only this filter."
+           "Toggle the \"%s\" filter. With ARG, use only this filter.
+This toggling is buffer-local, and doesn't affect the default
+behavior (determined by `prescient-filter-method')."
            filter-type-name)
          (interactive "P")
 
          ;; Make `prescient-filter-method' buffer-local in the
          ;; Selectrum buffer. We don't want to accidentally change the
-         ;; user's default settings.
+         ;; user's default behavior.
          (make-local-variable 'prescient-filter-method)
 
          (if arg

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -120,7 +120,7 @@ passed to `kbd', whose output will be bound in
                ;; Make sure the user doesn't accidentally disable all
                ;; filtering.
                (user-error
-                "Prescient.el: Can't toggle only filter method: %s"
+                "Prescient.el: Can't toggle off only active filter method: %s"
                 ,filter-type-name)
 
              (setq prescient-filter-method

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -73,58 +73,12 @@ For use on `selectrum-candidate-selected-hook'."
 (defvar selectrum-prescient--old-highlight-function nil
   "Previous value of `selectrum-highlight-candidates-function'.")
 
-;;;###autoload
-(define-minor-mode selectrum-prescient-mode
-  "Minor mode to use prescient.el in Selectrum menus."
-  :global t
-  :group 'prescient
-  (if selectrum-prescient-mode
-      (progn
-        ;; Prevent messing up variables if we explicitly enable the
-        ;; mode when it's already on.
-        (selectrum-prescient-mode -1)
-        (setq selectrum-prescient-mode t)
-        (setq selectrum-prescient--old-refine-function
-              selectrum-refine-candidates-function)
-        (setq selectrum-refine-candidates-function
-              #'prescient-filter)
-        (setq selectrum-prescient--old-preprocess-function
-              selectrum-preprocess-candidates-function)
-        (setq selectrum-preprocess-candidates-function
-              #'selectrum-prescient--preprocess)
-        (setq selectrum-prescient--old-highlight-function
-              selectrum-highlight-candidates-function)
-        (setq selectrum-highlight-candidates-function
-              #'selectrum-prescient--highlight)
-        (add-hook 'selectrum-candidate-selected-hook
-                  #'selectrum-prescient--remember)
-        (add-hook 'selectrum-candidate-inserted-hook
-                  #'selectrum-prescient--remember))
-    (when (eq selectrum-refine-candidates-function
-              #'prescient-filter)
-      (setq selectrum-refine-candidates-function
-            selectrum-prescient--old-refine-function))
-    (when (eq selectrum-preprocess-candidates-function
-              #'selectrum-prescient--preprocess)
-      (setq selectrum-preprocess-candidates-function
-            selectrum-prescient--old-preprocess-function))
-    (when (eq selectrum-highlight-candidates-function
-              #'selectrum-prescient--highlight)
-      (setq selectrum-highlight-candidates-function
-            selectrum-prescient--old-highlight-function))
-    (remove-hook 'selectrum-candidate-selected-hook
-                 #'selectrum-prescient--remember)
-    (remove-hook 'selectrum-candidate-inserted-hook
-                 #'selectrum-prescient--remember)))
-
-;;;; Commands
+;;;;; Toggling Commands
 (defvar selectrum-prescient-filter-toggle-map (make-sparse-keymap)
   "A keymap of commands for toggling Prescient filters in Selectrum.
 The toggling of commands is temporary and does not affect the
 default filtering settings determined by `prescient-filter-method'.")
 ;; Create a binding similar to the Isearch toggles.
-(define-key selectrum-minibuffer-map
-  "\M-s" selectrum-prescient-filter-toggle-map)
 
 (defmacro selectrum--prescient-create-and-bind-toggle-command
     (filter-type key-string)
@@ -181,6 +135,55 @@ passed to `kbd' which will be bound in
 (selectrum--prescient-create-and-bind-toggle-command literal "l")
 (selectrum--prescient-create-and-bind-toggle-command prefix "p")
 (selectrum--prescient-create-and-bind-toggle-command regexp "r")
+
+;;;###autoload
+(define-minor-mode selectrum-prescient-mode
+  "Minor mode to use prescient.el in Selectrum menus."
+  :global t
+  :group 'prescient
+  (if selectrum-prescient-mode
+      (progn
+        ;; Prevent messing up variables if we explicitly enable the
+        ;; mode when it's already on.
+        (selectrum-prescient-mode -1)
+        (setq selectrum-prescient-mode t)
+        (setq selectrum-prescient--old-refine-function
+              selectrum-refine-candidates-function)
+        (setq selectrum-refine-candidates-function
+              #'prescient-filter)
+        (setq selectrum-prescient--old-preprocess-function
+              selectrum-preprocess-candidates-function)
+        (setq selectrum-preprocess-candidates-function
+              #'selectrum-prescient--preprocess)
+        (setq selectrum-prescient--old-highlight-function
+              selectrum-highlight-candidates-function)
+        (setq selectrum-highlight-candidates-function
+              #'selectrum-prescient--highlight)
+        (add-hook 'selectrum-candidate-selected-hook
+                  #'selectrum-prescient--remember)
+        (add-hook 'selectrum-candidate-inserted-hook
+                  #'selectrum-prescient--remember)
+        (define-key selectrum-minibuffer-map
+          (kbd "M-s") selectrum-prescient-filter-toggle-map))
+    (when (eq selectrum-refine-candidates-function
+              #'prescient-filter)
+      (setq selectrum-refine-candidates-function
+            selectrum-prescient--old-refine-function))
+    (when (eq selectrum-preprocess-candidates-function
+              #'selectrum-prescient--preprocess)
+      (setq selectrum-preprocess-candidates-function
+            selectrum-prescient--old-preprocess-function))
+    (when (eq selectrum-highlight-candidates-function
+              #'selectrum-prescient--highlight)
+      (setq selectrum-highlight-candidates-function
+            selectrum-prescient--old-highlight-function))
+    (remove-hook 'selectrum-candidate-selected-hook
+                 #'selectrum-prescient--remember)
+    (remove-hook 'selectrum-candidate-inserted-hook
+                 #'selectrum-prescient--remember)
+    (when (equal (lookup-key selectrum-minibuffer-map (kbd "M-s"))
+                 selectrum-prescient-filter-toggle-map)
+      (define-key selectrum-minibuffer-map (kbd "M-s") nil))))
 
 ;;;; Closing remarks
 

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -108,8 +108,7 @@ passed to `kbd', whose output will be bound in
          (if arg
              ;; If user provides a prefix argument, set filtering to
              ;; be a list of only one filter type.
-             (setq prescient-filter-method
-                   (list (quote ,filter-type)))
+             (setq prescient-filter-method '(,filter-type))
 
            ;; Otherwise, if we need to add or remove from the list,
            ;; make sure it's actually a list.

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -139,32 +139,36 @@ passed to `kbd' which will be bound in
                                        filter-type-name))))
     `(progn
        (defun ,command-name
-           () ; Arg list
+           (arg) ; Arg list
          ,(format
-           "Toggle the \"%s\" filter."
+           "Toggle the \"%s\" filter. With ARG, use only this filter."
            filter-type-name)
-         (interactive)
+         (interactive "P")
 
-         ;; If needed, turn `prescient-filter-method' into a list of symbols.
-         (unless (listp prescient-filter-method)
-           (setq-local prescient-filter-method
-                       (list prescient-filter-method)))
+         (if arg
+             (setq-local prescient-filter-method
+                         (list (quote ,filter-type)))
 
-         ;; Add or remove the filtering method from `prescient-filter-method'
-         ;; and tell the user what happened.
-         (if (memq (quote ,filter-type)
-                   prescient-filter-method)
-             (progn
-               (setq-local prescient-filter-method
-                           (remove (quote ,filter-type)
-                                   prescient-filter-method))
-               (message "%s filter toggled off."
-                        ,(capitalize filter-type-name)))
-           (setq-local prescient-filter-method
-                       (cons (quote ,filter-type)
-                             prescient-filter-method))
-           (message "%s filter toggled on."
-                    ,(capitalize filter-type-name)))
+           ;; If needed, turn `prescient-filter-method' into a list of symbols.
+           (unless (listp prescient-filter-method)
+             (setq-local prescient-filter-method
+                         (list prescient-filter-method)))
+
+           ;; Add or remove the filtering method from `prescient-filter-method'
+           ;; and tell the user what happened.
+           (if (memq (quote ,filter-type)
+                     prescient-filter-method)
+               (progn
+                 (setq-local prescient-filter-method
+                             (remove (quote ,filter-type)
+                                     prescient-filter-method))
+                 (message "%s filter toggled off."
+                          ,(capitalize filter-type-name)))
+             (setq-local prescient-filter-method
+                         (cons (quote ,filter-type)
+                               prescient-filter-method))
+             (message "%s filter toggled on."
+                      ,(capitalize filter-type-name))))
 
          ;; Finally, update Selectrum's display.
          (selectrum-exhibit))

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -88,7 +88,7 @@ buffer-locally, and doesn't affect the default
 behavior (determined by `prescient-filter-method').
 
 FILTER-TYPE is an unquoted symbol that can be used in
-`prescient-filter-method'.  KEY-STRING is a string that can be
+`prescient-filter-method'. KEY-STRING is a string that can be
 passed to `kbd', whose output will be bound in
 `selectrum-prescient-toggle-map' to the created command."
   (let* ((filter-type-name (symbol-name filter-type)))
@@ -99,10 +99,10 @@ passed to `kbd', whose output will be bound in
                                filter-type-name))
            (arg) ; Arg list
          ,(format
-           "Toggle the \"%s\" filter. With ARG, use only this filter.
-This toggling is buffer-local, and doesn't affect the default
-behavior (determined by `prescient-filter-method')."
-           filter-type-name)
+           "Toggle the \"%s\" filter on or off. With ARG, use only this filter.
+This toggling only affects filtering in the current Selectrum
+buffer. It does not affect the default behavior (determined by
+`prescient-filter-method')."  filter-type-name)
          (interactive "P")
 
          ;; Make `prescient-filter-method' buffer-local in the

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -136,7 +136,7 @@ passed to `kbd' which will be bound in
                                  prescient-filter-method))))
 
            ;; Third, message the new value of `prescient-filter-method'.
-           (message "Prescient.el filter now %s"
+           (message "Prescient.el filter is now %s"
                     prescient-filter-method)
 
            ;; Finally, update Selectrum's display.

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -126,13 +126,13 @@ passed to `kbd', whose output will be bound in
              (setq prescient-filter-method
                    (if (memq ',filter-type prescient-filter-method)
                        (remq ',filter-type prescient-filter-method)
-                     (cons ',filter-type prescient-filter-method))))
+                     (cons ',filter-type prescient-filter-method)))))
 
-           ;; After changing `prescient-filter-method', tell the user
-           ;; the new value and update Selectrum's display.
-           (message "Prescient.el filter is now %s"
-                    prescient-filter-method)
-           (selectrum-exhibit))))))
+         ;; After changing `prescient-filter-method', tell the user
+         ;; the new value and update Selectrum's display.
+         (message "Prescient.el filter is now %s"
+                  prescient-filter-method)
+         (selectrum-exhibit)))))
 
 (selectrum--prescient-create-and-bind-toggle-command anchored "a")
 (selectrum--prescient-create-and-bind-toggle-command fuzzy "f")

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -106,7 +106,8 @@ passed to `kbd' which will be bound in
                  (eq prescient-filter-method
                      (quote ,filter-type)))
              (user-error
-              "Prescient.el: Can't disable only active filtering method")
+              "prescient.el: Can't toggle only filter method: %s"
+              ,filter-type-name)
 
            ;; Otherwise, change the buffer-local value of
            ;; `prescient-filter-method'.
@@ -136,7 +137,7 @@ passed to `kbd' which will be bound in
                                  prescient-filter-method))))
 
            ;; Third, message the new value of `prescient-filter-method'.
-           (message "Prescient.el filter is now %s"
+           (message "prescient.el filter is now %s"
                     prescient-filter-method)
 
            ;; Finally, update Selectrum's display.

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -119,10 +119,15 @@ For use on `selectrum-candidate-selected-hook'."
 
 ;;;; Commands
 (defvar selectrum-prescient-filter-toggle-map (make-sparse-keymap)
-  "A keymap containing commands to temporarily toggle the use of Prescient filters in Selectrum.")
+  "A keymap of commands for toggling Prescient filters in Selectrum.
+The toggling of commands is temporary and does not affect the
+default filtering settings determined by `prescient-filter-method'.")
 ;; Create a binding similar to the Isearch toggles.
-(define-key selectrum-minibuffer-map "\M-s" selectrum-prescient-filter-toggle-map)
+(defvar selectrum-minibuffer-map)
+(define-key selectrum-minibuffer-map
+  "\M-s" selectrum-prescient-filter-toggle-map)
 
+(declare-function selectrum-exhibit "selectrum")
 (defmacro selectrum--prescient-create-toggle-commands (filter-type key-string)
   "Create a command to toggle the use of FILTER-TYPE in Selectrum.
 FILTER-TYPE is an unquoted symbol which can be included in
@@ -135,8 +140,9 @@ passed to `kbd' which will be bound in
     `(progn
        (defun ,command-name
            () ; Arg list
-         ,(format "Toggle the use of Prescient's \"%s\" filter in the currently running Selectrum buffer."
-                  filter-type-name)
+         ,(format
+           "Toggle the \"%s\" filter."
+           filter-type-name)
          (interactive)
 
          ;; If needed, turn `prescient-filter-method' into a list of symbols.

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -130,8 +130,8 @@ passed to `kbd' which will be bound in
              (if (memq (quote ,filter-type)
                        prescient-filter-method)
                  (setq-local prescient-filter-method
-                             (remove (quote ,filter-type)
-                                     prescient-filter-method))
+                             (remq (quote ,filter-type)
+                                   prescient-filter-method))
                (setq-local prescient-filter-method
                            (cons (quote ,filter-type)
                                  prescient-filter-method))))

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -150,13 +150,15 @@ passed to `kbd' which will be bound in
              (setq-local prescient-filter-method
                          (list (quote ,filter-type)))
 
-           ;; If needed, turn `prescient-filter-method' into a list of symbols.
            (unless (listp prescient-filter-method)
+           ;; If needed, turn `prescient-filter-method' into a list of
+           ;; symbols.
              (setq-local prescient-filter-method
                          (list prescient-filter-method)))
 
-           ;; Add or remove the filtering method from `prescient-filter-method'
-           ;; and tell the user what happened.
+           ;; Add or remove the filtering method from
+           ;; `prescient-filter-method' and tell the user what
+           ;; happened.
            (if (memq (quote ,filter-type)
                      prescient-filter-method)
                (progn

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -127,7 +127,7 @@ default filtering settings determined by `prescient-filter-method'.")
 (define-key selectrum-minibuffer-map
   "\M-s" selectrum-prescient-filter-toggle-map)
 
-(declare-function selectrum-exhibit "selectrum")
+(declare-function selectrum-exhibit "ext:selectrum")
 (defmacro selectrum--prescient-create-and-bind-toggle-command
     (filter-type key-string)
   "Create a command to toggle the use of FILTER-TYPE in Selectrum.

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -88,12 +88,12 @@ FILTER-TYPE is an unquoted symbol that can be used in
 `prescient-filter-method'.  KEY-STRING is a string that can be
 passed to `kbd', whose output will be bound in
 `selectrum-prescient-toggle-map' to the created command."
-  (let* ((filter-type-name (symbol-name filter-type))
-         (command-name (intern (concat "selectrum-prescient-toggle-"
-                                       filter-type-name))))
-    `(progn
-       ;; First we create the toggling command.
-       (defun ,command-name
+  (let* ((filter-type-name (symbol-name filter-type)))
+
+    `(define-key selectrum-prescient-toggle-map
+       (kbd ,key-string)
+       (defun ,(intern (concat "selectrum-prescient-toggle-"
+                               filter-type-name))
            (arg) ; Arg list
          ,(format
            "Toggle the \"%s\" filter. With ARG, use only this filter."
@@ -132,12 +132,7 @@ passed to `kbd', whose output will be bound in
            ;; the new value and update Selectrum's display.
            (message "Prescient.el filter is now %s"
                     prescient-filter-method)
-           (selectrum-exhibit)))
-
-       ;; After defining the toggling command for `filter-type', bind
-       ;; it to the given `key-string'.
-       (define-key selectrum-prescient-toggle-map
-         (kbd ,key-string) (function ,command-name)))))
+           (selectrum-exhibit))))))
 
 (selectrum--prescient-create-and-bind-toggle-command anchored "a")
 (selectrum--prescient-create-and-bind-toggle-command fuzzy "f")

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -150,9 +150,9 @@ passed to `kbd' which will be bound in
              (setq-local prescient-filter-method
                          (list (quote ,filter-type)))
 
-           (unless (listp prescient-filter-method)
            ;; If needed, turn `prescient-filter-method' into a list of
            ;; symbols.
+           (when (nlistp prescient-filter-method)
              (setq-local prescient-filter-method
                          (list prescient-filter-method)))
 

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -99,44 +99,38 @@ passed to `kbd' which will be bound in
            filter-type-name)
          (interactive "P")
 
-         ;; Make sure the user doesn't accidentally disable all
-         ;; filtering.
-         (if (or (equal prescient-filter-method
-                        (list (quote ,filter-type)))
-                 (eq prescient-filter-method
-                     (quote ,filter-type)))
-             (user-error
-              "prescient.el: Can't toggle only filter method: %s"
-              ,filter-type-name)
+         ;; Make `prescient-filter-method' buffer-local in the
+         ;; Selectrum buffer. We don't want to accidentally change the
+         ;; user's default settings.
+         (make-local-variable 'prescient-filter-method)
 
-           ;; Otherwise, change the buffer-local value of
-           ;; `prescient-filter-method'.
-           (if arg
-               ;; If user provides a prefix argument, set filtering to
-               ;; be a list of only one filter type.
-               (setq-local prescient-filter-method
-                           (list (quote ,filter-type)))
+         (if arg
+             ;; If user provides a prefix argument, set filtering to
+             ;; be a list of only one filter type.
+             (setq prescient-filter-method
+                   (list (quote ,filter-type)))
 
-             ;; Without an argument, just add or remove `filter-type'
-             ;; from `prescient-filter-method'.
+           ;; Otherwise, if we need to add or remove from the list,
+           ;; make sure it's actually a list.
+           (when (nlistp prescient-filter-method)
+             (setq prescient-filter-method
+                   (list prescient-filter-method)))
 
-             ;; First, if needed, turn `prescient-filter-method' into a
-             ;; list of symbols.
-             (when (nlistp prescient-filter-method)
-               (setq-local prescient-filter-method
-                           (list prescient-filter-method)))
+           (if (equal prescient-filter-method '(,filter-type))
+               ;; Make sure the user doesn't accidentally disable all
+               ;; filtering.
+               (user-error
+                "prescient.el: Can't toggle only filter method: %s"
+                ,filter-type-name)
 
-             ;; Second, change `prescient-filter-method'.
-             (if (memq (quote ,filter-type)
-                       prescient-filter-method)
-                 (setq-local prescient-filter-method
-                             (remq (quote ,filter-type)
-                                   prescient-filter-method))
-               (setq-local prescient-filter-method
-                           (cons (quote ,filter-type)
-                                 prescient-filter-method))))
+             (setq
+              prescient-filter-method
+              (if (memq ',filter-type prescient-filter-method)
+                  (remq ',filter-type prescient-filter-method)
+                (cons ',filter-type prescient-filter-method))))
 
-           ;; Third, message the new value of `prescient-filter-method'.
+           ;; After changing `prescient-filter-method', tell user the
+           ;; new value.
            (message "prescient.el filter is now %s"
                     prescient-filter-method)
 

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -74,7 +74,7 @@ For use on `selectrum-candidate-selected-hook'."
   "Previous value of `selectrum-highlight-candidates-function'.")
 
 ;;;;; Toggling Commands
-(defvar selectrum-prescient-filter-toggle-map (make-sparse-keymap)
+(defvar selectrum-prescient-toggle-map (make-sparse-keymap)
   "A keymap of commands for toggling Prescient filters in Selectrum.
 The toggling of commands is temporary and does not affect the
 default filtering settings determined by `prescient-filter-method'.")
@@ -86,7 +86,7 @@ default filtering settings determined by `prescient-filter-method'.")
 FILTER-TYPE is an unquoted symbol which can be included in
 `prescient-filter-method'.  KEY-STRING is a string that can be
 passed to `kbd' which will be bound in
-`selectrum-prescient-filter-toggle-map'."
+`selectrum-prescient-toggle-map'."
   (let* ((filter-type-name (symbol-name filter-type))
          (command-name (intern (concat "selectrum-prescient-toggle-"
                                        filter-type-name))))
@@ -144,7 +144,7 @@ passed to `kbd' which will be bound in
 
        ;; After defining the toggling command for `filter-type', bind
        ;; it to the given `key-string'.
-       (define-key selectrum-prescient-filter-toggle-map
+       (define-key selectrum-prescient-toggle-map
          (kbd ,key-string) (function ,command-name)))))
 
 (selectrum--prescient-create-and-bind-toggle-command anchored "a")
@@ -182,7 +182,7 @@ passed to `kbd' which will be bound in
         (add-hook 'selectrum-candidate-inserted-hook
                   #'selectrum-prescient--remember)
         (define-key selectrum-minibuffer-map
-          (kbd "M-s") selectrum-prescient-filter-toggle-map))
+          (kbd "M-s") selectrum-prescient-toggle-map))
     (when (eq selectrum-refine-candidates-function
               #'prescient-filter)
       (setq selectrum-refine-candidates-function
@@ -200,7 +200,7 @@ passed to `kbd' which will be bound in
     (remove-hook 'selectrum-candidate-inserted-hook
                  #'selectrum-prescient--remember)
     (when (equal (lookup-key selectrum-minibuffer-map (kbd "M-s"))
-                 selectrum-prescient-filter-toggle-map)
+                 selectrum-prescient-toggle-map)
       (define-key selectrum-minibuffer-map (kbd "M-s") nil))))
 
 ;;;; Closing remarks

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -128,7 +128,7 @@ default filtering settings determined by `prescient-filter-method'.")
   "\M-s" selectrum-prescient-filter-toggle-map)
 
 (declare-function selectrum-exhibit "selectrum")
-(defmacro selectrum--prescient-create-toggle-commands (filter-type key-string)
+(defmacro selectrum--prescient-create-and-bind-toggle-command (filter-type key-string)
   "Create a command to toggle the use of FILTER-TYPE in Selectrum.
 FILTER-TYPE is an unquoted symbol which can be included in
 `prescient-filter-method'.  KEY-STRING is a string that can be
@@ -175,11 +175,11 @@ passed to `kbd' which will be bound in
        (define-key selectrum-prescient-filter-toggle-map
          (kbd ,key-string) (function ,command-name)))))
 
-(selectrum--prescient-create-toggle-commands fuzzy "f")
-(selectrum--prescient-create-toggle-commands initialism "i")
-(selectrum--prescient-create-toggle-commands literal "l")
-(selectrum--prescient-create-toggle-commands prefix "p")
-(selectrum--prescient-create-toggle-commands regexp "r")
+(selectrum--prescient-create-and-bind-toggle-command fuzzy "f")
+(selectrum--prescient-create-and-bind-toggle-command initialism "i")
+(selectrum--prescient-create-and-bind-toggle-command literal "l")
+(selectrum--prescient-create-and-bind-toggle-command prefix "p")
+(selectrum--prescient-create-and-bind-toggle-command regexp "r")
 
 ;;;; Closing remarks
 

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -82,11 +82,12 @@ default filtering settings determined by `prescient-filter-method'.")
 
 (defmacro selectrum--prescient-create-and-bind-toggle-command
     (filter-type key-string)
-  "Create a command to toggle the use of FILTER-TYPE in Selectrum.
-FILTER-TYPE is an unquoted symbol which can be included in
+  "Create and bind a command to toggle the use of FILTER-TYPE in Selectrum.
+
+FILTER-TYPE is an unquoted symbol that can be used in
 `prescient-filter-method'.  KEY-STRING is a string that can be
-passed to `kbd' which will be bound in
-`selectrum-prescient-toggle-map'."
+passed to `kbd', whose output will be bound in
+`selectrum-prescient-toggle-map' to the created command."
   (let* ((filter-type-name (symbol-name filter-type))
          (command-name (intern (concat "selectrum-prescient-toggle-"
                                        filter-type-name))))
@@ -120,7 +121,7 @@ passed to `kbd' which will be bound in
                ;; Make sure the user doesn't accidentally disable all
                ;; filtering.
                (user-error
-                "prescient.el: Can't toggle only filter method: %s"
+                "Prescient.el: Can't toggle only filter method: %s"
                 ,filter-type-name)
 
              (setq
@@ -131,7 +132,7 @@ passed to `kbd' which will be bound in
 
            ;; After changing `prescient-filter-method', tell user the
            ;; new value.
-           (message "prescient.el filter is now %s"
+           (message "Prescient.el filter is now %s"
                     prescient-filter-method)
 
            ;; Finally, update Selectrum's display.

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -123,18 +123,15 @@ passed to `kbd', whose output will be bound in
                 "Prescient.el: Can't toggle only filter method: %s"
                 ,filter-type-name)
 
-             (setq
-              prescient-filter-method
-              (if (memq ',filter-type prescient-filter-method)
-                  (remq ',filter-type prescient-filter-method)
-                (cons ',filter-type prescient-filter-method))))
+             (setq prescient-filter-method
+                   (if (memq ',filter-type prescient-filter-method)
+                       (remq ',filter-type prescient-filter-method)
+                     (cons ',filter-type prescient-filter-method))))
 
-           ;; After changing `prescient-filter-method', tell user the
-           ;; new value.
+           ;; After changing `prescient-filter-method', tell the user
+           ;; the new value and update Selectrum's display.
            (message "Prescient.el filter is now %s"
                     prescient-filter-method)
-
-           ;; Finally, update Selectrum's display.
            (selectrum-exhibit)))
 
        ;; After defining the toggling command for `filter-type', bind

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -136,7 +136,7 @@ passed to `kbd' which will be bound in
                                  prescient-filter-method))))
 
            ;; Third, message the new value of `prescient-filter-method'.
-           (message "Filter now %S"
+           (message "Prescient.el filter now %s"
                     prescient-filter-method)
 
            ;; Finally, update Selectrum's display.

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -128,7 +128,8 @@ default filtering settings determined by `prescient-filter-method'.")
   "\M-s" selectrum-prescient-filter-toggle-map)
 
 (declare-function selectrum-exhibit "selectrum")
-(defmacro selectrum--prescient-create-and-bind-toggle-command (filter-type key-string)
+(defmacro selectrum--prescient-create-and-bind-toggle-command
+    (filter-type key-string)
   "Create a command to toggle the use of FILTER-TYPE in Selectrum.
 FILTER-TYPE is an unquoted symbol which can be included in
 `prescient-filter-method'.  KEY-STRING is a string that can be

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -123,11 +123,9 @@ For use on `selectrum-candidate-selected-hook'."
 The toggling of commands is temporary and does not affect the
 default filtering settings determined by `prescient-filter-method'.")
 ;; Create a binding similar to the Isearch toggles.
-(defvar selectrum-minibuffer-map)
 (define-key selectrum-minibuffer-map
   "\M-s" selectrum-prescient-filter-toggle-map)
 
-(declare-function selectrum-exhibit "ext:selectrum")
 (defmacro selectrum--prescient-create-and-bind-toggle-command
     (filter-type key-string)
   "Create a command to toggle the use of FILTER-TYPE in Selectrum.

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -130,6 +130,7 @@ passed to `kbd' which will be bound in
        (define-key selectrum-prescient-filter-toggle-map
          (kbd ,key-string) (function ,command-name)))))
 
+(selectrum--prescient-create-and-bind-toggle-command anchored "a")
 (selectrum--prescient-create-and-bind-toggle-command fuzzy "f")
 (selectrum--prescient-create-and-bind-toggle-command initialism "i")
 (selectrum--prescient-create-and-bind-toggle-command literal "l")

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -125,7 +125,7 @@ passed to `kbd', whose output will be bound in
 
              (setq prescient-filter-method
                    (if (memq ',filter-type prescient-filter-method)
-                       (remq ',filter-type prescient-filter-method)
+                       (delq ',filter-type prescient-filter-method)
                      (cons ',filter-type prescient-filter-method)))))
 
          ;; After changing `prescient-filter-method', tell the user

--- a/stub/selectrum.el
+++ b/stub/selectrum.el
@@ -5,6 +5,9 @@
 (defvar selectrum-refine-candidates-function nil)
 (defvar selectrum-preprocess-candidates-function nil)
 (defvar selectrum-highlight-candidates-function nil)
+(defvar selectrum-minibuffer-map nil)
 (defvar selectrum-should-sort-p nil)
+
+(defun selectrum-exhibit ())
 
 (provide 'selectrum)


### PR DESCRIPTION
While using Selectrum, I sometimes want to change what filtering method the current search is using, similar to Isearch's `isearch-toggle-*` commands. This pull request adds commands for this to selectrum-prescient.el.

Currently, this toggling only affects the running Selectrum buffer. Using a prefix argument with a command locally sets `prescient-filter-method` to only use the method corresponding to that command.

Is there anything that you would like changed?