### PR TITLE
Fix prefix filter and document anchor filter

### DIFF
--- a/prescient.el
+++ b/prescient.el
@@ -105,6 +105,10 @@ in order, separated by the same non-word characters that separate
 words in the query. This is similar to the completion style
 `partial'.
 
+Value `anchored' means words are separated by capital letters or
+symbols, with capital letters being the start of a new word. This
+is similar to `prefix', but allows for less typing.
+
 Value can also be a list of any of the above methods, in which
 case each method will be applied in order until one matches.
 

--- a/prescient.el
+++ b/prescient.el
@@ -381,17 +381,16 @@ that case by separating queries with a space.
 If WITH-GROUPS is non-nil, enclose the parts of the regexp that
 match the QUERY characters in capture groups, so that the match
 data can be used to highlight the matched substrings."
-  (when (string-match-p "[[:word:]][^[:word:]]" query)
-      (prescient--with-group
-       (concat "\\<"
-               (replace-regexp-in-string
-                "[^[:word:]]"
-                (lambda (s) (concat "[[:word:]]*" (regexp-quote s)))
-                query
-                ;; Since quoting the non-word character,
-                ;; must replace literally.
-                'fixed-case 'literal))
-       with-groups)))
+  (prescient--with-group
+   (concat "\\<"
+           (replace-regexp-in-string
+            "[^[:word:]]"
+            (lambda (s) (concat "[[:word:]]*" (regexp-quote s)))
+            query
+            ;; Since quoting the non-word character, must replace
+            ;; literally.
+            'fixed-case 'literal))
+   with-groups))
 
 ;;;; Sorting and filtering
 

--- a/prescient.el
+++ b/prescient.el
@@ -385,26 +385,17 @@ that case by separating queries with a space.
 If WITH-GROUPS is non-nil, enclose the parts of the regexp that
 match the QUERY characters in capture groups, so that the match
 data can be used to highlight the matched substrings."
-  (if with-groups
-      ;; This might put capture groups around empty strings in some
-      ;; cases, but that shouldn't matter.
-      (concat "\\<\\("
-              (replace-regexp-in-string
-               "[^[:word:]]"
-               (lambda (s) (concat "\\)[[:word:]]*"
-                                   (regexp-quote s)
-                                   "\\("))
-               query
-               ;; Since quoting the non-word character, must replace
-               ;; literally.
-               'fixed-case 'literal)
-              "\\)")
-    (concat "\\<"
-            (replace-regexp-in-string
-             "[^[:word:]]"
-             (lambda (s) (concat "[[:word:]]*" (regexp-quote s)))
-             query
-             'fixed-case 'literal))))
+  (replace-regexp-in-string
+   "[[:word:]]+"
+   (if with-groups
+       (lambda (s) (concat "\\(" s "\\)[[:word:]]*"))
+     "\\&[[:word:]]*")
+   ;; Quote non-word characters so that they're taken
+   ;; literally.
+   (replace-regexp-in-string "[^[:word:]]"
+                             (lambda (s) (regexp-quote s))
+                             query 'fixed-case 'literal)
+   'fixed-case with-groups))
 
 ;;;; Sorting and filtering
 

--- a/prescient.el
+++ b/prescient.el
@@ -385,17 +385,23 @@ that case by separating queries with a space.
 If WITH-GROUPS is non-nil, enclose the parts of the regexp that
 match the QUERY characters in capture groups, so that the match
 data can be used to highlight the matched substrings."
-  (replace-regexp-in-string
-   "[[:word:]]+"
-   (if with-groups
-       (lambda (s) (concat "\\(" s "\\)[[:word:]]*"))
-     "\\&[[:word:]]*")
-   ;; Quote non-word characters so that they're taken
-   ;; literally.
-   (replace-regexp-in-string "[^[:word:]]"
-                             (lambda (s) (regexp-quote s))
-                             query 'fixed-case 'literal)
-   'fixed-case with-groups))
+  (let ((str (replace-regexp-in-string
+              "[[:word:]]+"
+              ;; Choose whether to wrap sequences of word characters.
+              (if with-groups
+                  (lambda (s) (concat "\\(" s "\\)[[:word:]]*"))
+                "\\&[[:word:]]*")
+              ;; Quote non-word characters so that they're taken
+              ;; literally.
+              (replace-regexp-in-string "[^[:word:]]"
+                                        (lambda (s) (regexp-quote s))
+                                        query 'fixed-case 'literal)
+              'fixed-case with-groups)))
+    ;; If regexp begins with a word character, make sure regexp
+    ;; doesn't start matching in the middle of a word.
+    (if (= 0 (string-match-p "[[:word:]]" str))
+        (concat "\\<" str)
+      str)))
 
 ;;;; Sorting and filtering
 

--- a/prescient.el
+++ b/prescient.el
@@ -385,16 +385,26 @@ that case by separating queries with a space.
 If WITH-GROUPS is non-nil, enclose the parts of the regexp that
 match the QUERY characters in capture groups, so that the match
 data can be used to highlight the matched substrings."
-  (prescient--with-group
-   (concat "\\<"
-           (replace-regexp-in-string
-            "[^[:word:]]"
-            (lambda (s) (concat "[[:word:]]*" (regexp-quote s)))
-            query
-            ;; Since quoting the non-word character, must replace
-            ;; literally.
-            'fixed-case 'literal))
-   with-groups))
+  (if with-groups
+      ;; This might put capture groups around empty strings in some
+      ;; cases, but that shouldn't matter.
+      (concat "\\<\\("
+              (replace-regexp-in-string
+               "[^[:word:]]"
+               (lambda (s) (concat "\\)[[:word:]]*"
+                                   (regexp-quote s)
+                                   "\\("))
+               query
+               ;; Since quoting the non-word character, must replace
+               ;; literally.
+               'fixed-case 'literal)
+              "\\)")
+    (concat "\\<"
+            (replace-regexp-in-string
+             "[^[:word:]]"
+             (lambda (s) (concat "[[:word:]]*" (regexp-quote s)))
+             query
+             'fixed-case 'literal))))
 
 ;;;; Sorting and filtering
 


### PR DESCRIPTION
This fixes #74.

Previously, the prefix filter only activated if the query had a non-word character. This has been fixed.

The anchored filter method was not documented in the documentation string of `prescient-filter-method`. This has been fixed.

It has been noted in #74 that the two methods are very similar, which can cause confusion. Maybe prefix filtering should be changed?
