### PR TITLE
Create a custom variable containing an alist of filter symbols and functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,13 +58,13 @@ The format is based on [Keep a Changelog].
 
   The functions that produce the regexps used for searching candidates
   are now considered public. They are
-  - prescient-anchored-regexp
-  - prescient-fuzzy-regexp
-  - prescient-initials-regexp
-  - prescient-literal-regexp
-  - prescient-prefix-regexp
-  - prescient-regexp-regexp
-  - prescient-with-group
+    - `prescient-anchored-regexp`
+    - `prescient-fuzzy-regexp`
+    - `prescient-initials-regexp`
+    - `prescient-literal-regexp`
+    - `prescient-prefix-regexp`
+    - `prescient-regexp-regexp`
+    - `prescient-with-group`
 
 [#66]: https://github.com/raxod502/prescient.el/pull/66
 [#67]: https://github.com/raxod502/prescient.el/pull/67

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ The format is based on [Keep a Changelog].
     | `M-s p` | `selectrum-prescient-toggle-prefix`     |
     | `M-s r` | `selectrum-prescient-toggle-regexp`     |
 
-* The custom variable `prescient-filter-alist` was added, which
+* The user option `prescient-filter-alist` was added, which
   describes the relationship between the symbols in
   `prescient-filter-list` and the corresponding functions that produce
   regular expressions for matching candidates. Users can create their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ The format is based on [Keep a Changelog].
     | `M-s p` | `selectrum-prescient-toggle-prefix`     |
     | `M-s r` | `selectrum-prescient-toggle-regexp`     |
 
+* The custom variable `prescient-filter-alist` was added, which
+  describes the relationship between the symbols in
+  `prescient-filter-list` and the corresponding functions that produce
+  regular expressions for matching candidates. Users can create their
+  own filter methods by adding a symbol-function pair to
+  `prescient-filter-alist` and use that custom method by adding the
+  symbol to `prescient-filter-method`.
+
 [#66]: https://github.com/raxod502/prescient.el/pull/66
 [#67]: https://github.com/raxod502/prescient.el/pull/67
 [#70]: https://github.com/raxod502/prescient.el/pull/70

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,13 @@ The format is based on [Keep a Changelog].
   regular expressions for matching candidates. Users can create their
   own filter methods by adding a symbol-function pair to
   `prescient-filter-alist` and use that custom method by adding the
-  symbol to `prescient-filter-method`.
+  symbol to `prescient-filter-method`. See [#77].
 
 [#66]: https://github.com/raxod502/prescient.el/pull/66
 [#67]: https://github.com/raxod502/prescient.el/pull/67
 [#70]: https://github.com/raxod502/prescient.el/pull/70
 [#72]: https://github.com/raxod502/prescient.el/pull/72
+[#77]: https://github.com/raxod502/prescient.el/pull/77
 
 ## 5.0 (release 2020-07-16)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,16 @@ The format is based on [Keep a Changelog].
   `prescient-filter-alist` and use that custom method by adding the
   symbol to `prescient-filter-method`. See [#77].
 
+  The functions that produce the regexps used for searching candidates
+  are now considered public. They are
+  - prescient-anchored-regexp
+  - prescient-fuzzy-regexp
+  - prescient-initials-regexp
+  - prescient-literal-regexp
+  - prescient-prefix-regexp
+  - prescient-regexp-regexp
+  - prescient-with-group
+
 [#66]: https://github.com/raxod502/prescient.el/pull/66
 [#67]: https://github.com/raxod502/prescient.el/pull/67
 [#70]: https://github.com/raxod502/prescient.el/pull/70

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,10 @@ The format is based on [Keep a Changelog].
     respective filtering method and toggles off all others.
   * While `selectrum-prescient-mode` is enabled, `M-s` is bound to
     `selectrum-prescient-toggle-map` in the Selectrum buffer, and is
-    used as a prefix key to access the commands.
+    used as a prefix key to access the commands. The macro
+    `selectrum-prescient-create-and-bind-toggle-command` can be used
+    to create a toggling command for a filter, and bind that command
+    in `selectrum-prescient-toggle-map`.
 
     | Key     | Command                                 |
     |---------|-----------------------------------------|

--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ used as a prefix key to access the commands.
 | `M-s p` | `selectrum-prescient-toggle-prefix`     |
 | `M-s r` | `selectrum-prescient-toggle-regexp`     |
 
+When defining custom filter methods, you can create new bindings using
+`selectrum-prescient-create-and-bind-toggle-command`, which takes an
+unquoted filter symbol and a string that can be used by `kbd`. For
+example,
+
+``` emacs-lisp
+(selectrum-prescient-create-and-bind-toggle-command my-foo "M-f")
+```
+
+will bind a command to toggle the `my-foo` filter to `M-s M-f`.
+
 ## Contributor guide
 
 Please see [the contributor guide for my

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ When defining custom filter methods, you can create new bindings using
 unquoted filter symbol and a string that can be used by `kbd`. For
 example,
 
-``` emacs-lisp
+```emacs-lisp
 (selectrum-prescient-create-and-bind-toggle-command my-foo "M-f")
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ different one by customizing `prescient-filter-method`.
   matching or any combination of those. See the docstring for full
   details.
 
+* `prescient-filter-alist`: An alist of symbol-function pairs that
+  associate a symbol in `prescient-filter-method` with a function that
+  creates a regexp for matching a candidate. You can add to this alist
+  to define your own custom filter methods, and use them by adding the
+  appropriate symbol to `prescient-filter-method`.
+
 ### Ivy-specific
 The following user options are specific to using `prescient.el` with
 Ivy:

--- a/prescient.el
+++ b/prescient.el
@@ -120,22 +120,22 @@ be `literal+initialism', which equivalent to the list (`literal'
           (const :tag "Anchored" anchored)))
 
 (defcustom prescient-filter-alist
-  '((literal . prescient--literal-regexp)
-    (initialism . prescient--initials-regexp)
-    (regexp . prescient--regexp-regexp)
-    (fuzzy . prescient--fuzzy-regexp)
-    (prefix . prescient--prefix-regexp)
-    (anchored . prescient--anchored-regexp))
+  '((literal . prescient-literal-regexp)
+    (initialism . prescient-initials-regexp)
+    (regexp . prescient-regexp-regexp)
+    (fuzzy . prescient-fuzzy-regexp)
+    (prefix . prescient-prefix-regexp)
+    (anchored . prescient-anchored-regexp))
   "An alist of filter methods and their functions.
 
-These symbols can be included `prescient-filter-method', and
+These symbols can be included in `prescient-filter-method', and
 their corresponding functions will be used to create regexps for
 matching candidates.
 
 A function should take two arguments: the query for which it is
 to create a regexp, and a boolean that describes whether it
 should enclose matched text in capture groups (such as with
-`prescient--with-group')."
+`prescient-with-group')."
   :type '(alist :key-type symbol :value-type function))
 
 (defcustom prescient-sort-length-enable t
@@ -315,20 +315,20 @@ as a sub-query delimiter."
       ;; We added the subqueries in reverse order.
       (nreverse subqueries))))
 
-(defun prescient--with-group (regexp with-group)
+(defun prescient-with-group (regexp with-group)
   "Wrap REGEXP in a capture group, but only if WITH-GROUP is non-nil."
   (if with-group
       (format "\\(%s\\)" regexp)
     regexp))
 
-(defun prescient--literal-regexp (query &optional with-groups)
+(defun prescient-literal-regexp (query &optional with-groups)
   "Return a regexp matching QUERY with character folding.
 If WITH-GROUPS is `all', enclose the match in a capture group."
-  (prescient--with-group
+  (prescient-with-group
    (char-fold-to-regexp query)
    (eq with-groups 'all)))
 
-(defun prescient--initials-regexp (query &optional with-groups)
+(defun prescient-initials-regexp (query &optional with-groups)
   "Return a regexp matching QUERY as an initialism.
 This means that the regexp will only match a given string if
 QUERY is a substring of the initials of the string.
@@ -348,14 +348,14 @@ capture groups matching \"f\" and \"a\"."
              query
              "\\W*"))
 
-(defun prescient--regexp-regexp (query &optional _)
+(defun prescient-regexp-regexp (query &optional _)
   "Unless using the regexp QUERY would return an error, return QUERY."
   (ignore-errors
     ;; Ignore regexp if it's malformed.
     (string-match-p query "")
     query))
 
-(defun prescient--anchored-regexp (query &optional with-groups)
+(defun prescient-anchored-regexp (query &optional with-groups)
   "Return a regexp matching QUERY with anchors.
 This means uppercase and symbols will be used as begin of words.
 
@@ -380,7 +380,7 @@ or \"find-f-a\"."
      'fixed-case
      'literal)))
 
-(defun prescient--fuzzy-regexp (query &optional with-groups)
+(defun prescient-fuzzy-regexp (query &optional with-groups)
   "Return a regexp for fuzzy-matching QUERY.
 This means that the regexp will only match a given string if
 all characters in QUERY are present anywhere in the string in
@@ -391,20 +391,20 @@ match the QUERY characters in capture groups, so that the match
 data can be used to highlight the matched substrings."
   (let ((chars (string-to-list query)))
     (concat
-     (prescient--with-group
+     (prescient-with-group
       (regexp-quote
        (char-to-string (car chars)))
       with-groups)
      (mapconcat
       (lambda (char)
         (format "[^%c\n]*?%s" char
-                (prescient--with-group
+                (prescient-with-group
                  (regexp-quote
                   (char-to-string char))
                  with-groups)))
       (cdr chars) ""))))
 
-(defun prescient--prefix-regexp (query &optional with-groups)
+(defun prescient-prefix-regexp (query &optional with-groups)
   "Return a regexp for matching the beginnings of words in QUERY.
 This is similar to the `partial-completion' completion style provided
 by Emacs, except that non-word characters are taken literally
@@ -415,7 +415,7 @@ If WITH-GROUPS is non-nil, enclose the parts of the regexp that
 match the QUERY characters in capture groups, so that the match
 data can be used to highlight the matched substrings."
   (when (string-match-p "[[:word:]][^[:word:]]" query)
-      (prescient--with-group
+      (prescient-with-group
        (concat "\\<"
                (replace-regexp-in-string
                 "[^[:word:]]"

--- a/prescient.el
+++ b/prescient.el
@@ -329,6 +329,13 @@ capture groups matching \"f\" and \"a\"."
              query
              "\\W*"))
 
+(defun prescient--regexp-regexp (query &optional _)
+  "Unless using the regexp QUERY would return an error, return QUERY."
+  (ignore-errors
+    ;; Ignore regexp if it's malformed.
+    (string-match-p query "")
+    query))
+
 (defun prescient--anchored-regexp (query &optional with-groups)
   "Return a regexp matching QUERY with anchors.
 This means uppercase and symbols will be used as begin of words.
@@ -423,10 +430,7 @@ enclose literal substrings with capture groups."
             (`initialism
              (prescient--initials-regexp subquery with-groups))
             (`regexp
-             (ignore-errors
-               ;; Ignore regexp if it's malformed.
-               (string-match-p subquery "")
-               subquery))
+             (prescient--regexp-regexp subquery with-groups))
             (`fuzzy
              (prescient--fuzzy-regexp subquery with-groups))
             (`prefix

--- a/prescient.el
+++ b/prescient.el
@@ -302,6 +302,13 @@ as a sub-query delimiter."
       (format "\\(%s\\)" regexp)
     regexp))
 
+(defun prescient--literal-regexp (query &optional with-groups)
+  "Return a regexp matching QUERY with character folding.
+If WITH-GROUPS is `all', enclose the match in a capture group."
+  (prescient--with-group
+   (char-fold-to-regexp query)
+   (eq with-groups 'all)))
+
 (defun prescient--initials-regexp (query &optional with-groups)
   "Return a regexp matching QUERY as an initialism.
 This means that the regexp will only match a given string if
@@ -412,9 +419,7 @@ enclose literal substrings with capture groups."
         (lambda (method)
           (pcase method
             (`literal
-             (prescient--with-group
-              (char-fold-to-regexp subquery)
-              (eq with-groups 'all)))
+             (prescient--literal-regexp subquery with-groups))
             (`initialism
              (prescient--initials-regexp subquery with-groups))
             (`regexp

--- a/prescient.el
+++ b/prescient.el
@@ -135,7 +135,9 @@ matching candidates.
 A function should take two arguments: the query for which it is
 to create a regexp, and a boolean that describes whether it
 should enclose matched text in capture groups (such as with
-`prescient-with-group')."
+`prescient-with-group'). Additionally, if the boolean is the
+symbol `all', then literal substrings should be enclosed in
+capture groups."
   :type '(alist :key-type symbol :value-type function))
 
 (defcustom prescient-sort-length-enable t

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -79,7 +79,7 @@ For use on `selectrum-candidate-selected-hook'."
 Such commands are created and automatically bound in this map by
 `selectrum--prescient-create-and-bind-toggle-command'.")
 
-(defmacro selectrum--prescient-create-and-bind-toggle-command
+(defmacro selectrum-prescient-create-and-bind-toggle-command
     (filter-type key-string)
   "Create and bind a command to toggle the use of a filter method in Selectrum.
 
@@ -139,12 +139,12 @@ buffer. It does not affect the default behavior (determined by
                   prescient-filter-method)
          (selectrum-exhibit)))))
 
-(selectrum--prescient-create-and-bind-toggle-command anchored "a")
-(selectrum--prescient-create-and-bind-toggle-command fuzzy "f")
-(selectrum--prescient-create-and-bind-toggle-command initialism "i")
-(selectrum--prescient-create-and-bind-toggle-command literal "l")
-(selectrum--prescient-create-and-bind-toggle-command prefix "p")
-(selectrum--prescient-create-and-bind-toggle-command regexp "r")
+(selectrum-prescient-create-and-bind-toggle-command anchored "a")
+(selectrum-prescient-create-and-bind-toggle-command fuzzy "f")
+(selectrum-prescient-create-and-bind-toggle-command initialism "i")
+(selectrum-prescient-create-and-bind-toggle-command literal "l")
+(selectrum-prescient-create-and-bind-toggle-command prefix "p")
+(selectrum-prescient-create-and-bind-toggle-command regexp "r")
 
 ;;;###autoload
 (define-minor-mode selectrum-prescient-mode


### PR DESCRIPTION
Hello.

This pull request is meant to allow easier extending of `prescient.el`, by adding the custom variable `prescient-filter-alist`.

Users can add a pair of a symbol (which names the filter method) and a function (which creates a regexp) to the alist, and then add that symbol to `prescient-filter-method`. This keeps compatibility with existing settings.

This approach is mentioned in #69, where it is shown that [CTRLF does something similar](https://github.com/raxod502/prescient.el/issues/69#issuecomment-700017374). While CTRLF's use is more complicated, I think that just associating a symbol with a function is currently enough for `prescient.el`.

I moved the code for `literal` and `regexp` matching to their own functions, and tried to keep the naming scheme of `prescient--FILTER-regexp`. This gives `prescient--regexp-regexp`, which isn't a very helpful name, but I'm unsure of what to change it to.

Thank you.