### PR TITLE
New prescient-filter-method literal-prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format is based on [Keep a Changelog].
 
 ## Unreleased
 ### Enhancements
+* Literal-prefix matching, a new filter method whose behavior is that
+  the first subquery must be the prefix of the candidate and the
+  remaining subqueries must be prefixes of words in the
+  candidate. Supports char folding just like `literal`.
+  
+  For example, if the input is `foo bar`, then the candidate must
+  begin with `foo`, and it must also contain a word starting with
+  `bar`.  That means it would match `foo-and-bar` or `fooboo-barquux`
+  but not `bar-foo` (because that doesn't start with `foo`) or
+  `foo-qbar` (because `bar` is no prefix of some word).
+  
+  It can be enabled by adding `literal-prefix` to
+  `prescient-filter-method`.
+
 * Anchored matching, a new filtering method that uses uppercase
   letters and symbols as beginning of word, similar to initialism.
   It can be enabled by adding `anchored` to

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ different one by customizing `prescient-filter-method`.
   candidates. The default is `literal`, `regexp`, and `initialism` as
   described above, but you can also use substring matching, initialism
   matching, regexp matching, fuzzy matching, prefix matching, anchored
-  matching or any combination of those. See the docstring for full
-  details.
+  matching, literal-prefix matching, or any combination of those. See
+  the docstring for full details.
 
 * `prescient-filter-alist`: An alist of symbol-function pairs that
   associate a symbol in `prescient-filter-method` with a function that


### PR DESCRIPTION
The new `prescient-filter-method` value `literal-prefix` means the
first subquery must be the prefix of the candidate and the remaining
subqueries must be prefixes of words in the candidate.  Supports char
folding (just like `literal`).

As such, it is quite similar to `literal` except that it does strict
prefix matching instead of substring matching.

It is also similar to `prefix` except that it forces that the first
subquery matches at the beginning of the candidate.  Furthermore, it
only highlights the subqueries literally whereas the `prefix` method
highlights the complete matching words.

I'm happy to also update the `CHANGELOG.md` if this PR gets merged but
didn't do it right now so that different PRs don't provoke conflicts
in there.

----

# 

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->