### PR TITLE
Introduce selectrum-prescient faces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,9 +78,12 @@ The format is based on [Keep a Changelog].
     - `prescient-prefix-regexp`
     - `prescient-regexp-regexp`
     - `prescient-with-group`
-* The faces `selectrum-primary-highlight` and
-  `selectrum-secondary-highlight` are now a part of
-  `selectrum-prescient.el` rather than Selectrum proper ([#94])
+* To configure match highlighting you can use the faces
+`selectrum-prescient-primary-highlight` and
+`selectrum-prescient-secondary-highlight`. The previously used
+Selectrum faces `selectrum-primary-highlight` and
+`selectrum-secondary-highlight` will get removed from Selectrum proper
+([#94], [#97]).
 
 * The user option `prescient-sort-full-matches-first` was added. If
   non-nil, candidates that are fully matched are sorted before
@@ -95,6 +98,7 @@ The format is based on [Keep a Changelog].
 [#77]: https://github.com/raxod502/prescient.el/pull/77
 [#94]: https://github.com/raxod502/prescient.el/pull/94
 [#95]: https://github.com/raxod502/prescient.el/pull/95
+[#97]: https://github.com/raxod502/prescient.el/pull/97
 
 ## 5.0 (release 2020-07-16)
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -179,6 +179,35 @@ example,
 
 will bind a command to toggle the `my-foo` filter to `M-s M-f`.
 
+The part of each candidate that matches your input is highlighted with
+the face `selectrum-prescient-primary-highlight`. There is also
+`selectrum-prescient-secondary-highlight` for additional highlighting of
+specific matched parts of the input.
+
+The following example shows customizing these faces, I use the
+[Zerodark](https://github.com/NicolasPetton/zerodark-theme) color
+theme, which includes colors for Ivy, but not for Selectrum. I
+inspected the theme source code to see what colors were being used for
+Ivy, and copied them to be used for Selectrum as well:
+
+```elisp
+(require 'zerodark-theme)
+
+(let ((class '((class color) (min-colors 89))))
+  (custom-theme-set-faces
+   'zerodark
+   `(selectrum-current-candidate
+     ((,class (:background "#48384c"
+                           :weight bold
+                           :foreground "#c678dd"))))
+   `(selectrum-prescient-primary-highlight
+   ((,class (:foreground "#da8548"))))
+   `(selectrum-prescient-secondary-highlight
+   ((,class (:foreground "#98be65"))))))
+
+(enable-theme 'zerodark)
+```
+
 ## Contributor guide
 
 Please see [the contributor guide for my

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -28,19 +28,35 @@
 
 (require 'subr-x)
 
-;;;; Faces
+;;;; Customization
 
-(defface selectrum-primary-highlight
+(defgroup selectrum-prescient nil
+  "Prescient adapter for Selectrum."
+  :group 'convenience
+  :prefix "selectrum-prescient"
+  :link '(url-link "https://github.com/raxod502/prescient.el"))
+
+(define-obsolete-face-alias
+  'selectrum-primary-highlight
+  'selectrum-prescient-primary-highlight
+  t)
+
+(define-obsolete-face-alias
+  'selectrum-secondary-highlight
+  'selectrum-prescient-secondary-highlight
+  t)
+
+(defface selectrum-prescient-primary-highlight
   '((t :weight bold))
   "Face used to highlight the parts of candidates that match the input."
-  :group 'selectrum-faces)
+  :group 'selectrum-prescient)
 
-(defface selectrum-secondary-highlight
-  '((t :inherit selectrum-primary-highlight :underline t))
+(defface selectrum-prescient-secondary-highlight
+  '((t :inherit selectrum-prescient-primary-highlight :underline t))
   "Additional face used to highlight parts of candidates.
 May be used to highlight parts of candidates that match specific
 parts of the input."
-  :group 'selectrum-faces)
+  :group 'selectrum-prescient)
 
 ;;;; Minor mode
 
@@ -73,7 +89,7 @@ For use on `selectrum-candidate-selected-hook'."
              (when (string-match regexp candidate)
                (put-text-property
                 (match-beginning 0) (match-end 0)
-                'face 'selectrum-primary-highlight candidate)
+                'face 'selectrum-prescient-primary-highlight candidate)
                (cl-loop
                 for (start end)
                 on (cddr (match-data))
@@ -81,7 +97,8 @@ For use on `selectrum-candidate-selected-hook'."
                 do (when (and start end)
                      (put-text-property
                       start end
-                      'face 'selectrum-secondary-highlight candidate)))))))
+                      'face 'selectrum-prescient-secondary-highlight
+                      candidate)))))))
        candidates))))
 
 (defvar selectrum-prescient--old-highlight-function nil


### PR DESCRIPTION
I defined the obsolete aliases now, the old faces can still be used. I will deprecate them in Selectrum, too so we can remove them there eventually.
