### PR TITLE
Add user option `prescient-use-char-folding`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,8 @@ Selectrum faces `selectrum-primary-highlight` and
 
 * The user option `prescient-use-char-folding` was added. If non-nil,
   the `literal` and `literal-prefix` filter methods will use character
-  folding. See [#98].
+  folding. See [#98]. This can be used to help avoid the problems
+  reported in [#92] and [#93].
 
 [#66]: https://github.com/raxod502/prescient.el/pull/66
 [#67]: https://github.com/raxod502/prescient.el/pull/67
@@ -102,6 +103,8 @@ Selectrum faces `selectrum-primary-highlight` and
 [#72]: https://github.com/raxod502/prescient.el/pull/72
 [#76]: https://github.com/raxod502/prescient.el/pull/76
 [#77]: https://github.com/raxod502/prescient.el/pull/77
+[#92]: https://github.com/raxod502/prescient.el/issues/92
+[#93]: https://github.com/raxod503/prescient.el/issues/93
 [#94]: https://github.com/raxod502/prescient.el/pull/94
 [#95]: https://github.com/raxod502/prescient.el/pull/95
 [#97]: https://github.com/raxod502/prescient.el/pull/97

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ Selectrum faces `selectrum-primary-highlight` and
 
 * The user option `prescient-use-char-folding` was added. If non-nil,
   the `literal` and `literal-prefix` filter methods will use character
-  folding.
+  folding. See [#98].
 
 [#66]: https://github.com/raxod502/prescient.el/pull/66
 [#67]: https://github.com/raxod502/prescient.el/pull/67
@@ -105,6 +105,7 @@ Selectrum faces `selectrum-primary-highlight` and
 [#94]: https://github.com/raxod502/prescient.el/pull/94
 [#95]: https://github.com/raxod502/prescient.el/pull/95
 [#97]: https://github.com/raxod502/prescient.el/pull/97
+[#98]: https://github.com/raxod502/prescient.el/pull/98
 
 ## 5.0 (release 2020-07-16)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,14 +52,16 @@ The format is based on [Keep a Changelog].
     to create a toggling command for a filter, and bind that command
     in `selectrum-prescient-toggle-map`.
 
-    | Key     | Command                                 |
-    |---------|-----------------------------------------|
-    | `M-s a` | `selectrum-prescient-toggle-anchored`   |
-    | `M-s f` | `selectrum-prescient-toggle-fuzzy`      |
-    | `M-s i` | `selectrum-prescient-toggle-initialism` |
-    | `M-s l` | `selectrum-prescient-toggle-literal`    |
-    | `M-s p` | `selectrum-prescient-toggle-prefix`     |
-    | `M-s r` | `selectrum-prescient-toggle-regexp`     |
+    | Key     | Command                                     |
+    |---------|---------------------------------------------|
+    | `M-s a` | `selectrum-prescient-toggle-anchored`       |
+    | `M-s f` | `selectrum-prescient-toggle-fuzzy`          |
+    | `M-s i` | `selectrum-prescient-toggle-initialism`     |
+    | `M-s l` | `selectrum-prescient-toggle-literal`        |
+    | `M-s p` | `selectrum-prescient-toggle-prefix`         |
+    | `M-s P` | `selectrum-prescient-toggle-literal-prefix` |
+    | `M-s r` | `selectrum-prescient-toggle-regexp`         |
+    | `M-s '` | `selectrum-prescient-toggle-char-fold`      |
 
 * The user option `prescient-filter-alist` was added, which
   describes the relationship between the symbols in
@@ -89,6 +91,10 @@ Selectrum faces `selectrum-primary-highlight` and
   non-nil, candidates that are fully matched are sorted before
   partially matched candidates, though all candidates still follow the
   order of recency, frequency, and length. See [#95].
+
+* The user option `prescient-use-char-folding` was added. If non-nil,
+  the `literal` and `literal-prefix` filter methods will use character
+  folding.
 
 [#66]: https://github.com/raxod502/prescient.el/pull/66
 [#67]: https://github.com/raxod502/prescient.el/pull/67

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ different one by customizing `prescient-filter-method`.
   candidates that are fully matched before candidates that are
   partially matched.
 
+* `prescient-use-char-folding`: Whether the `literal` and
+  `literal-prefix` filter methods use character folding.
+
 ### Company-specific
 
 * `company-prescient-sort-length-enable`: By default, the standard
@@ -159,14 +162,16 @@ same time. While `selectrum-prescient-mode` is enabled, `M-s` is bound
 to `selectrum-prescient-toggle-map` in the Selectrum buffer, and is
 used as a prefix key to access the commands.
 
-| Key     | Command                                 |
-|---------|-----------------------------------------|
-| `M-s a` | `selectrum-prescient-toggle-anchored`   |
-| `M-s f` | `selectrum-prescient-toggle-fuzzy`      |
-| `M-s i` | `selectrum-prescient-toggle-initialism` |
-| `M-s l` | `selectrum-prescient-toggle-literal`    |
-| `M-s p` | `selectrum-prescient-toggle-prefix`     |
-| `M-s r` | `selectrum-prescient-toggle-regexp`     |
+| Key     | Command                                     |
+|---------|---------------------------------------------|
+| `M-s a` | `selectrum-prescient-toggle-anchored`       |
+| `M-s f` | `selectrum-prescient-toggle-fuzzy`          |
+| `M-s i` | `selectrum-prescient-toggle-initialism`     |
+| `M-s l` | `selectrum-prescient-toggle-literal`        |
+| `M-s p` | `selectrum-prescient-toggle-prefix`         |
+| `M-s P` | `selectrum-prescient-toggle-literal-prefix` |
+| `M-s r` | `selectrum-prescient-toggle-regexp`         |
+| `M-s '` | `selectrum-prescient-toggle-char-fold`      |
 
 When defining custom filter methods, you can create new bindings using
 `selectrum-prescient-create-and-bind-toggle-command`, which takes an

--- a/prescient.el
+++ b/prescient.el
@@ -198,8 +198,9 @@ still be sorted like normal."
 
 This affects the `literal' and `literal-prefix' filtering methods.
 
-See also the customizable variables `char-fold-include',
-`char-fold-exclude', and `char-fold-symmetric'."
+In Emacs versions 27 or greater, see also the customizable
+variables `char-fold-include', `char-fold-exclude', and
+`char-fold-symmetric'."
   :type 'boolean)
 
 ;;;; Caches

--- a/prescient.el
+++ b/prescient.el
@@ -193,6 +193,15 @@ partially matched candidates, but candidates in each group will
 still be sorted like normal."
   :type 'boolean)
 
+(defcustom prescient-use-char-folding t
+  "Whether certain literal filtering methods use character folding.
+
+This affects the `literal' and `literal-prefix' filtering methods.
+
+See also the customizable variables `char-fold-include',
+`char-fold-exclude', and `char-fold-symmetric'."
+  :type 'boolean)
+
 ;;;; Caches
 
 (defvar prescient--history (make-hash-table :test 'equal)
@@ -358,19 +367,27 @@ as a sub-query delimiter."
 
 (cl-defun prescient-literal-regexp (query &key with-group
                                           &allow-other-keys)
-  "Return a regexp matching QUERY with character folding.
-If WITH-GROUP is `all', enclose the match in a capture group."
+  "Return a regexp matching QUERY with optional character folding.
+
+If WITH-GROUP is `all', enclose the match in a capture group.
+
+See also the customizable variable `prescient-use-char-folding'."
   (prescient-with-group
-   (char-fold-to-regexp query)
+   (if prescient-use-char-folding
+       (char-fold-to-regexp query)
+     query)
    (eq with-group 'all)))
 
 (cl-defun prescient-literal-prefix-regexp
     (query &key with-group subquery-number
            &allow-other-keys)
-  "Return a regexp matching QUERY with character folding.
+  "Return a regexp matching QUERY with optional character folding.
+
 If WITH-GROUP is `all', enclose the match in a capture group.
 Anchor the QUERY at the beginning of the candidate if
-SUBQUERY-NUMBER equals 0."
+SUBQUERY-NUMBER equals 0.
+
+See also the customizable variable `prescient-use-char-folding'."
   (prescient-with-group
    (concat (if (= subquery-number 0)
                ;; 1. subquery => anchor at the beginning of candidate.
@@ -378,7 +395,9 @@ SUBQUERY-NUMBER equals 0."
              ;; Otherwise, just anchor at the beginning of some word
              ;; in the candidate.
              "\\b")
-           (char-fold-to-regexp query))
+           (if prescient-use-char-folding
+               (char-fold-to-regexp query)
+             query))
    (eq with-group 'all)))
 
 (cl-defun prescient-initials-regexp (query &key with-group

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -177,6 +177,25 @@ buffer. It does not affect the default behavior (determined by
 (selectrum-prescient-create-and-bind-toggle-command prefix "p")
 (selectrum-prescient-create-and-bind-toggle-command regexp "r")
 
+(defun selectrum-prescient-toggle-char-fold ()
+  "Toggle character folding in the current Selectrum buffer.
+
+See the customizable variable `prescient-use-char-folding'."
+  (interactive)
+  ;; Make sure that this change is local only to the current Selectrum
+  ;; buffer.
+  (setq-local prescient-use-char-folding
+              (not prescient-use-char-folding))
+  ;; After changing `prescient-use-char-folding', tell the user
+  ;; the new value and update Selectrum's display.
+  (message "Character folding toggled %s"
+           (if prescient-use-char-folding "on" "off"))
+  (selectrum-exhibit))
+
+;; Matches `isearch-toggle-char-fold'.
+(define-key selectrum-prescient-toggle-map (kbd "'")
+  #'selectrum-prescient-toggle-char-fold)
+
 ;;;###autoload
 (define-minor-mode selectrum-prescient-mode
   "Minor mode to use prescient.el in Selectrum menus."

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -183,12 +183,8 @@ buffer. It does not affect the default behavior (determined by
 
 See the customizable variable `prescient-use-char-folding'."
   (interactive)
-  ;; Make sure that this change is local only to the current Selectrum
-  ;; buffer.
   (setq-local prescient-use-char-folding
               (not prescient-use-char-folding))
-  ;; After changing `prescient-use-char-folding', tell the user
-  ;; the new value and update Selectrum's display.
   (message "Character folding toggled %s"
            (if prescient-use-char-folding "on" "off"))
   (selectrum-exhibit))

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -178,20 +178,18 @@ buffer. It does not affect the default behavior (determined by
 (selectrum-prescient-create-and-bind-toggle-command prefix "p")
 (selectrum-prescient-create-and-bind-toggle-command regexp "r")
 
-(defun selectrum-prescient-toggle-char-fold ()
-  "Toggle character folding in the current Selectrum buffer.
+;; This is the same binding used by `isearch-toggle-char-fold'.
+(define-key selectrum-prescient-toggle-map (kbd "'")
+  (defun selectrum-prescient-toggle-char-fold ()
+    "Toggle character folding in the current Selectrum buffer.
 
 See the customizable variable `prescient-use-char-folding'."
-  (interactive)
-  (setq-local prescient-use-char-folding
-              (not prescient-use-char-folding))
-  (message "Character folding toggled %s"
-           (if prescient-use-char-folding "on" "off"))
-  (selectrum-exhibit))
-
-;; Matches `isearch-toggle-char-fold'.
-(define-key selectrum-prescient-toggle-map (kbd "'")
-  #'selectrum-prescient-toggle-char-fold)
+    (interactive)
+    (setq-local prescient-use-char-folding
+                (not prescient-use-char-folding))
+    (message "Character folding toggled %s"
+             (if prescient-use-char-folding "on" "off"))
+    (selectrum-exhibit)))
 
 ;;;###autoload
 (define-minor-mode selectrum-prescient-mode

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -174,6 +174,7 @@ buffer. It does not affect the default behavior (determined by
 (selectrum-prescient-create-and-bind-toggle-command fuzzy "f")
 (selectrum-prescient-create-and-bind-toggle-command initialism "i")
 (selectrum-prescient-create-and-bind-toggle-command literal "l")
+(selectrum-prescient-create-and-bind-toggle-command literal-prefix "P")
 (selectrum-prescient-create-and-bind-toggle-command prefix "p")
 (selectrum-prescient-create-and-bind-toggle-command regexp "r")
 


### PR DESCRIPTION
Hello.

These are the changes:

- Add an option to use character folding for the `literal` and `literal-prefix` filter methods. This should help address #92 and #93.
- Add a command in Selectrum Prescient to toggle this setting, bound to `M-s '` (mirroring `isearch-toggle-char-fold`).
- Add a command to toggle the `literal-prefix` filter method, which wasn't done when this method was added.
- Update the documentation to reflect these changes.

Is there anything that you would like changed?

Thank you.