### PR TITLE
Obsolete alias: `selectrum-should-sort-p' -> `selectrum-should-sort'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,16 +22,18 @@ The format is based on [Keep a Changelog].
   folding. See [#98]. This can be used to help avoid the problems
   reported in [#92] and [#93].
 
+### Internal changes
+* The user option `selectrum-should-sort-p` was deprecated in
+  Selectrum 3.1 in favor of `selectrum-should-sort`.
+  `selectrum-prescient.el` now uses the updated option name ([#99]).
+
 [#92]: https://github.com/raxod502/prescient.el/issues/92
 [#93]: https://github.com/raxod503/prescient.el/issues/93
 [#94]: https://github.com/raxod502/prescient.el/pull/94
 [#95]: https://github.com/raxod502/prescient.el/pull/95
 [#97]: https://github.com/raxod502/prescient.el/pull/97
 [#98]: https://github.com/raxod502/prescient.el/pull/98
-
-### Removed
-* Use `selectrum-should-sort`, introduced in Selectrum 3.1, over the
-  obsolete alias `selectrum-should-sort-p`.
+[#99]: https://github.com/raxod502/prescient.el/pull/99
 
 ## 5.1 (released 2021-02-26)
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ The format is based on [Keep a Changelog].
 [#97]: https://github.com/raxod502/prescient.el/pull/97
 [#98]: https://github.com/raxod502/prescient.el/pull/98
 
+### Removed
+* Use `selectrum-should-sort`, introduced in Selectrum 3.1, over the
+  obsolete alias `selectrum-should-sort-p`.
+
 ## 5.1 (released 2021-02-26)
 ### Enhancements
 * Literal-prefix matching, a new filter method whose behavior is that

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -6,7 +6,7 @@
 ;; Homepage: https://github.com/raxod502/prescient.el
 ;; Keywords: extensions
 ;; Created: 8 Dec 2019
-;; Package-Requires: ((emacs "25.1") (prescient "5.1") (selectrum "1.0"))
+;; Package-Requires: ((emacs "25.1") (prescient "5.1") (selectrum "3.1"))
 ;; SPDX-License-Identifier: MIT
 ;; Version: 5.1
 
@@ -61,8 +61,8 @@ parts of the input."
 ;;;; Minor mode
 
 (defun selectrum-prescient--preprocess (candidates)
-  "Sort CANDIDATES, unless `selectrum-should-sort-p' is nil."
-  (when selectrum-should-sort-p
+  "Sort CANDIDATES, unless `selectrum-should-sort' is nil."
+  (when selectrum-should-sort
     (setq candidates (prescient-sort candidates)))
   candidates)
 

--- a/stub/selectrum.el
+++ b/stub/selectrum.el
@@ -6,7 +6,7 @@
 (defvar selectrum-preprocess-candidates-function nil)
 (defvar selectrum-highlight-candidates-function nil)
 (defvar selectrum-minibuffer-map nil)
-(defvar selectrum-should-sort-p nil)
+(defvar selectrum-should-sort nil)
 
 (defun selectrum-exhibit ())
 


### PR DESCRIPTION
<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
