### PR TITLE
selectrum-prescient: Add options to configure filtering and sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog].
 
 ## Unreleased
 ### New features
+* Two new user options, `selectrum-prescient-enable-filtering` and
+  `selectrum-prescient-enable-sorting`, which allow the user to
+  selectively disable the filtering or sorting functionalities of
+  `selectrum-prescient.el` ([#100]).
 * New command `selectrum-prescient-toggle-char-fold`, bound to `M-s '`
   in the minibuffer.
 * To configure match highlighting you can use the faces
@@ -28,6 +32,7 @@ The format is based on [Keep a Changelog].
 [#95]: https://github.com/raxod502/prescient.el/pull/95
 [#97]: https://github.com/raxod502/prescient.el/pull/97
 [#98]: https://github.com/raxod502/prescient.el/pull/98
+[#100]: https://github.com/raxod502/prescient.el/pull/100
 
 ## 5.1 (released 2021-02-26)
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ This is because loading Counsel results in a number of changes being
 made to the user options of Ivy, which `ivy-prescient.el` must then
 undo.
 
+The modes handle sorting and filtering by default. See the package
+specific sections for options to configure this.
+
 ## Algorithm
 
 `prescient.el` takes as input a list of candidates, and a query that
@@ -144,6 +147,19 @@ Ivy:
   and how to customize it manually.
 
 ### Selectrum-specific
+The following user options are specific to using `prescient.el` with
+Selectrum:
+
+* `selectrum-prescient-enable-filtering`: If set to nil, then
+  `selectrum-prescient.el` does not change filtering of Selectrum. See
+  the Selectrum documentation for information on how Selectrum
+  configures filtering by default, and how to customize it manually.
+
+* `selectrum-prescient-enable-sorting`: If set to nil, then
+  `selectrum-prescient.el` does not change sorting of Selectrum. See
+  the Selectrum documentation for information on how Selectrum
+  configures sorting by default, and how to customize it manually.
+
 `selectrum-prescient.el` provides special commands (see the table
 below) to adjust how `prescient.el` filters candidates in the current
 Selectrum buffer.
@@ -184,10 +200,11 @@ example,
 
 will bind a command to toggle the `my-foo` filter to `M-s M-f`.
 
-The part of each candidate that matches your input is highlighted with
-the face `selectrum-prescient-primary-highlight`. There is also
-`selectrum-prescient-secondary-highlight` for additional highlighting of
-specific matched parts of the input.
+With `selectrum-prescient-enable-filtering` set, the part of each
+candidate that matches your input is highlighted with the face
+`selectrum-prescient-primary-highlight`. There is also
+`selectrum-prescient-secondary-highlight` for additional highlighting
+of specific matched parts of the input.
 
 The following example shows customizing these faces, I use the
 [Zerodark](https://github.com/NicolasPetton/zerodark-theme) color

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -58,6 +58,26 @@ May be used to highlight parts of candidates that match specific
 parts of the input."
   :group 'selectrum-prescient)
 
+(defcustom selectrum-prescient-enable-filtering t
+  "Whether to enable filtering by `selectrum-prescient'.
+If nil, then `selectrum-prescient-mode' does not change the
+filtering behavior of Selectrum from the default. See Selectrum
+documentation for how to configure filtering yourself. Changing
+this variable will not take effect until
+`selectrum-prescient-mode' has been reloaded."
+  :group 'selectrum-prescient
+  :type 'boolean)
+
+(defcustom selectrum-prescient-enable-sorting t
+  "Whether to enable sorting by `selectrum-prescient'.
+If nil, then `selectrum-prescient-mode' does not change the
+sorting behavior of Selectrum from the default. See Selectrum
+documentation for how to configure sorting yourself. Changing
+this variable will not take effect until
+`selectrum-prescient-mode' has been reloaded."
+  :group 'selectrum-prescient
+  :type 'boolean)
+
 ;;;; Minor mode
 
 (defun selectrum-prescient--preprocess (candidates)
@@ -202,32 +222,30 @@ See the customizable variable `prescient-use-char-folding'."
         ;; mode when it's already on.
         (selectrum-prescient-mode -1)
         (setq selectrum-prescient-mode t)
-        (setq selectrum-prescient--old-refine-function
-              selectrum-refine-candidates-function)
-        (setq selectrum-refine-candidates-function
-              #'prescient-filter)
-        (setq selectrum-prescient--old-preprocess-function
-              selectrum-preprocess-candidates-function)
-        (setq selectrum-preprocess-candidates-function
-              #'selectrum-prescient--preprocess)
-        (setq selectrum-prescient--old-highlight-function
-              selectrum-highlight-candidates-function)
-        (setq selectrum-highlight-candidates-function
-              #'selectrum-prescient--highlight)
-        (add-hook 'selectrum-candidate-selected-hook
-                  #'selectrum-prescient--remember)
-        (add-hook 'selectrum-candidate-inserted-hook
-                  #'selectrum-prescient--remember)
-        (define-key selectrum-minibuffer-map
-          (kbd "M-s") selectrum-prescient-toggle-map))
+        (when selectrum-prescient-enable-filtering
+          (setq selectrum-prescient--old-refine-function
+                selectrum-refine-candidates-function)
+          (setq selectrum-prescient--old-highlight-function
+                selectrum-highlight-candidates-function)
+          (setq selectrum-refine-candidates-function
+                #'prescient-filter)
+          (setq selectrum-highlight-candidates-function
+                #'selectrum-prescient--highlight)
+          (define-key selectrum-minibuffer-map
+            (kbd "M-s") selectrum-prescient-toggle-map))
+        (when selectrum-prescient-enable-sorting
+          (setq selectrum-prescient--old-preprocess-function
+                selectrum-preprocess-candidates-function)
+          (setq selectrum-preprocess-candidates-function
+                #'selectrum-prescient--preprocess)
+          (add-hook 'selectrum-candidate-selected-hook
+                    #'selectrum-prescient--remember)
+          (add-hook 'selectrum-candidate-inserted-hook
+                    #'selectrum-prescient--remember)))
     (when (eq selectrum-refine-candidates-function
               #'prescient-filter)
       (setq selectrum-refine-candidates-function
             selectrum-prescient--old-refine-function))
-    (when (eq selectrum-preprocess-candidates-function
-              #'selectrum-prescient--preprocess)
-      (setq selectrum-preprocess-candidates-function
-            selectrum-prescient--old-preprocess-function))
     (when (eq selectrum-highlight-candidates-function
               #'selectrum-prescient--highlight)
       (setq selectrum-highlight-candidates-function
@@ -238,7 +256,11 @@ See the customizable variable `prescient-use-char-folding'."
                  #'selectrum-prescient--remember)
     (when (equal (lookup-key selectrum-minibuffer-map (kbd "M-s"))
                  selectrum-prescient-toggle-map)
-      (define-key selectrum-minibuffer-map (kbd "M-s") nil))))
+      (define-key selectrum-minibuffer-map (kbd "M-s") nil))
+    (when (eq selectrum-preprocess-candidates-function
+              #'selectrum-prescient--preprocess)
+      (setq selectrum-preprocess-candidates-function
+            selectrum-prescient--old-preprocess-function))))
 
 ;;;; Closing remarks
 

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -250,13 +250,13 @@ See the customizable variable `prescient-use-char-folding'."
               #'selectrum-prescient--highlight)
       (setq selectrum-highlight-candidates-function
             selectrum-prescient--old-highlight-function))
+    (when (equal (lookup-key selectrum-minibuffer-map (kbd "M-s"))
+                 selectrum-prescient-toggle-map)
+      (define-key selectrum-minibuffer-map (kbd "M-s") nil))
     (remove-hook 'selectrum-candidate-selected-hook
                  #'selectrum-prescient--remember)
     (remove-hook 'selectrum-candidate-inserted-hook
                  #'selectrum-prescient--remember)
-    (when (equal (lookup-key selectrum-minibuffer-map (kbd "M-s"))
-                 selectrum-prescient-toggle-map)
-      (define-key selectrum-minibuffer-map (kbd "M-s") nil))
     (when (eq selectrum-preprocess-candidates-function
               #'selectrum-prescient--preprocess)
       (setq selectrum-preprocess-candidates-function


### PR DESCRIPTION
Similar like for ivy it is useful to be able to configure these now that we have several options for Selectrum, too.