### PR TITLE
Add user option and toggling command for case folding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ The format is based on [Keep a Changelog].
   the `literal` and `literal-prefix` filter methods will use character
   folding. See [#98]. This can be used to help avoid the problems
   reported in [#92] and [#93].
+* The user option `prescient-use-case-folding` was added.  This
+  feature affects the use of all filters.  It can be one of `nil`,
+  `t`, or `smart` (the default).  If `smart`, then case folding is
+  disabled when upper-case characters are sought.  In Selectrum, the
+  toggling command `selectrum-prescient-toggle-case-fold` was bound to
+  `M-s c`.  See [#PR].
 
 ### Enhancements
 * `selectrum-prescient.el`: Match faces are now combined with faces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog].
   `t`, or `smart` (the default).  If `smart`, then case folding is
   disabled when upper-case characters are sought.  In Selectrum, the
   toggling command `selectrum-prescient-toggle-case-fold` was bound to
-  `M-s c`.  See [#PR].
+  `M-s c`.  See [#105].
 
 ### Enhancements
 * `selectrum-prescient.el`: Match faces are now combined with faces
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog].
 [#100]: https://github.com/raxod502/prescient.el/pull/100
 [#101]: https://github.com/raxod503/prescient.el/issues/101
 [#103]: https://github.com/raxod502/prescient.el/pull/103
+[#105]: https://github.com/raxod502/prescient.el/pull/105
 
 ## 5.1 (released 2021-02-26)
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ used as a prefix key to access the commands.
 | `M-s P` | `selectrum-prescient-toggle-literal-prefix` |
 | `M-s r` | `selectrum-prescient-toggle-regexp`         |
 | `M-s '` | `selectrum-prescient-toggle-char-fold`      |
+| `M-s c` | `selectrum-prescient-toggle-case-fold`      |
 
 When defining custom filter methods, you can create new bindings using
 `selectrum-prescient-create-and-bind-toggle-command`, which takes an

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ different one by customizing `prescient-filter-method`.
 * `prescient-use-char-folding`: Whether the `literal` and
   `literal-prefix` filter methods use character folding.
 
+* `prescient-use-case-folding`: Whether filtering methods use case
+  folding (in non-Emacs terms, whether they are not case-sensitive).
+  This can be one of `nil`, `t`, or `smart` (the default).  If
+  `smart`, then case folding is disabled when upper-case characters
+  are sought.
+
 ### Company-specific
 
 * `company-prescient-sort-length-enable`: By default, the standard

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -230,19 +230,21 @@ Otherwise, this toggles between normal case folding and no case
 folding."
   (interactive)
   (setq-local prescient-use-case-folding
-              (if prescient-use-case-folding
-                  (progn
-                    (message "Case folding toggled off")
-                    nil)
-                (if (eq (default-toplevel-value 'prescient-use-case-folding)
-                        'smart)
-                    (progn
-                      (message "Smart case folding toggled on")
-                      'smart)
-                  (message "Case folding toggled on")
-                  t)))
+              (cond
+               (prescient-use-case-folding
+                (message "Case folding toggled off")
+                nil)
+               ((eq (default-toplevel-value 'prescient-use-case-folding)
+                    'smart)
+                (message "Smart case folding toggled on")
+                'smart)
+               (t
+                (message "Case folding toggled on")
+                t)))
+
   (selectrum-exhibit))
 
+;; This is the same binding used by `isearch-toggle-case-fold'.
 (define-key selectrum-prescient-toggle-map (kbd "c")
   #'selectrum-prescient-toggle-case-fold)
 

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -99,7 +99,15 @@ For use on `selectrum-candidate-selected-hook'."
 
 (defun selectrum-prescient--highlight (input candidates)
   "According to INPUT, return list of propertized CANDIDATES."
-  (let ((regexps (prescient-filter-regexps input 'with-groups)))
+  (let ((regexps (prescient-filter-regexps input 'with-groups))
+        (case-fold-search (if (eq prescient-use-case-folding
+                                  'smart)
+                              (let ((case-fold-search nil))
+                                ;; If using upper-case characters,
+                                ;; then don't fold case.
+                                (not (string-match-p "[[:upper:]]"
+                                                     input)))
+                            prescient-use-case-folding)))
     (save-match-data
       (mapcar
        (lambda (candidate)
@@ -212,6 +220,31 @@ See the customizable variable `prescient-use-char-folding'."
 ;; This is the same binding used by `isearch-toggle-char-fold'.
 (define-key selectrum-prescient-toggle-map (kbd "'")
   #'selectrum-prescient-toggle-char-fold)
+
+(defun selectrum-prescient-toggle-case-fold ()
+  "Toggle case folding in the current Selectrum buffer.
+
+If `prescient-use-case-folding' is set to `smart', then this
+toggles whether to use smart case folding or no case folding.
+Otherwise, this toggles between normal case folding and no case
+folding."
+  (interactive)
+  (setq-local prescient-use-case-folding
+              (if prescient-use-case-folding
+                  (progn
+                    (message "Case folding toggled off")
+                    nil)
+                (if (eq (default-toplevel-value 'prescient-use-case-folding)
+                        'smart)
+                    (progn
+                      (message "Smart case folding toggled on")
+                      'smart)
+                  (message "Case folding toggled on")
+                  t)))
+  (selectrum-exhibit))
+
+(define-key selectrum-prescient-toggle-map (kbd "c")
+  #'selectrum-prescient-toggle-case-fold)
 
 ;;;###autoload
 (define-minor-mode selectrum-prescient-mode


### PR DESCRIPTION
- Add the user option `prescient-use-case-folding`.  If `smart`, disable case folding when upper-case characters are sought.  This affects the use of all filters.
- Add toggling command bound to `M-s c` for Selectrum Prescient. If the `default-toplevel-value` of the above option is `smart`, this toggles between `smart` and `nil`. Otherwise, this toggles between `t` and `nil`.
