### PR TITLE
Fix typo of `:with-groups` to `:with-group` in `prescient-filter-regexps`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ The format is based on [Keep a Changelog].
   Selectrum 3.1 in favor of `selectrum-should-sort`.
   `selectrum-prescient.el` now uses the updated option name ([#99]).
 
-### Bugs Fixes
+### Bugs fixed
 * A typo was fixed that prevented secondary highlighting (such as the
   initials in `initialism` matching) from being applied.  Functions in
   `prescient-filter-alist` were being passed the keyword argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ The format is based on [Keep a Changelog].
   Selectrum 3.1 in favor of `selectrum-should-sort`.
   `selectrum-prescient.el` now uses the updated option name ([#99]).
 
+### Bugs Fixes
+* A typo was fixed that prevented secondary highlighting (such as the
+  initials in `initialism` matching) from being applied.  Functions in
+  `prescient-filter-alist` were being passed the keyword argument
+  `:with-groups` instead of the correct `:with-group`.  For
+  consistency, the `with-groups` argument of
+  `prescient-filter-regexps` was changed to `with-group`.  See [#106].
+
 [#92]: https://github.com/raxod502/prescient.el/issues/92
 [#93]: https://github.com/raxod503/prescient.el/issues/93
 [#94]: https://github.com/raxod502/prescient.el/pull/94
@@ -54,6 +62,7 @@ The format is based on [Keep a Changelog].
 [#101]: https://github.com/raxod503/prescient.el/issues/101
 [#103]: https://github.com/raxod502/prescient.el/pull/103
 [#105]: https://github.com/raxod502/prescient.el/pull/105
+[#106]: https://github.com/raxod502/prescient.el/pull/106
 
 ## 5.1 (released 2021-02-26)
 ### Enhancements

--- a/ivy-prescient.el
+++ b/ivy-prescient.el
@@ -103,7 +103,7 @@ This is for use in `ivy-re-builders-alist'."
        query
        (if ivy-prescient-retain-classic-highlighting
            'all
-         'with-groups)))
+         'with-group)))
      ;; For some reason, Ivy doesn't seem to like to be given an empty
      ;; list of regexps. Instead, it wants an empty string.
      "")))

--- a/prescient.el
+++ b/prescient.el
@@ -522,12 +522,12 @@ data can be used to highlight the matched substrings."
 
 ;;;; Sorting and filtering
 
-(defun prescient-filter-regexps (query &optional with-groups)
+(defun prescient-filter-regexps (query &optional with-group)
   "Convert QUERY to list of regexps.
 Each regexp must match the candidate in order for a candidate to
 match the QUERY.
 
-If WITH-GROUPS is non-nil, enclose the initials in initialisms
+If WITH-GROUP is non-nil, enclose the initials in initialisms
 with capture groups. If it is the symbol `all', additionally
 enclose literal substrings with capture groups."
   (let ((subquery-number 0))
@@ -540,7 +540,7 @@ enclose literal substrings with capture groups."
                  (lambda (method)
                    (if-let ((func (alist-get method prescient-filter-alist)))
                        (funcall func subquery
-                                :with-group with-groups
+                                :with-group with-group
                                 :subquery-number subquery-number)
                      ;; Don't throw error if function doesn't exist, but do
                      ;; warn user.

--- a/prescient.el
+++ b/prescient.el
@@ -540,7 +540,7 @@ enclose literal substrings with capture groups."
                  (lambda (method)
                    (if-let ((func (alist-get method prescient-filter-alist)))
                        (funcall func subquery
-                                :with-groups with-groups
+                                :with-group with-groups
                                 :subquery-number subquery-number)
                      ;; Don't throw error if function doesn't exist, but do
                      ;; warn user.

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -99,7 +99,7 @@ For use on `selectrum-candidate-selected-hook'."
 
 (defun selectrum-prescient--highlight (input candidates)
   "According to INPUT, return list of propertized CANDIDATES."
-  (let ((regexps (prescient-filter-regexps input 'with-groups))
+  (let ((regexps (prescient-filter-regexps input 'with-group))
         (case-fold-search (if (eq prescient-use-case-folding
                                   'smart)
                               (let ((case-fold-search nil))


### PR DESCRIPTION
All of the filtering functions take the keyword argument
`:with-group`.  This was previously the normal argument `with-groups`.

This fixes the highlighting of secondary information, such as the initials for the `initialism` filter style.

@raxod502, some functions use "with-group" and others "with-groups". Do you want to standardize on a particular form?