### PR TITLE
Add command `prescient-forget`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The format is based on [Keep a Changelog].
   disabled when upper-case characters are sought.  In Selectrum, the
   toggling command `selectrum-prescient-toggle-case-fold` was bound to
   `M-s c`.  See [#105].
+* The command `prescient-forget` was added. When used, `prescient.el`
+  will immediately forget a candidate ([#109]).
 
 ### Enhancements
 * `selectrum-prescient.el`: Match faces are now combined with faces
@@ -63,6 +65,7 @@ The format is based on [Keep a Changelog].
 [#103]: https://github.com/raxod502/prescient.el/pull/103
 [#105]: https://github.com/raxod502/prescient.el/pull/105
 [#106]: https://github.com/raxod502/prescient.el/pull/106
+[#109]: https://github.com/raxod502/prescient.el/pull/109
 
 ## 5.1 (released 2021-02-26)
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ ones, and then the remaining candidates are sorted by length. If you
 don't like the algorithm used for filtering, you can choose a
 different one by customizing `prescient-filter-method`.
 
+If you would like `prescient.el` to forget about a candidate, use the
+command `prescient-forget`.
+
 ## Configuration and other features
 
 * `prescient-history-length`: The number of recently selected

--- a/prescient.el
+++ b/prescient.el
@@ -252,6 +252,20 @@ This is used to determine which set of changes to the save file
 should \"win\" when two concurrent Emacs sessions want to modify
 it.")
 
+(defun prescient-forget (candidate)
+  "Remove CANDIDATE from recency and frequency records."
+  (interactive
+   (list (completing-read "Forget candidate: "
+                          ;; Since candidates are shared, select from
+                          ;; the table with the most candidates.
+                          (if (> (hash-table-size prescient--frequency)
+                                 (hash-table-size prescient--history))
+                              prescient--frequency
+                            prescient--history)
+                          nil t)))
+  (remhash candidate prescient--history)
+  (remhash candidate prescient--frequency))
+
 ;;;; Persistence
 
 (defvar prescient--cache-version 5


### PR DESCRIPTION
Add a command to forget a candidate. This is desirable after making a mistake.

Do you think that it is worth sorting the candidates in any particular order? Since `prescient.el` is already being used, a bad candidate recently used would be sorted somewhere near the top of the list, yes?