### PR TITLE
Support function as the value of prescient-filter-method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The format is based on [Keep a Changelog].
 
 ### Enhancements
 * `prescient-filter-method` accepts a function which returns the
-  desired filter methods ([#110])
+  desired filter methods ([#110]).
 * `selectrum-prescient.el`: Match faces are now combined with faces
   that might be already present on candidates instead of replacing
   them which gives better visual results in these cases ([#101],
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog].
 [#103]: https://github.com/raxod502/prescient.el/pull/103
 [#105]: https://github.com/raxod502/prescient.el/pull/105
 [#106]: https://github.com/raxod502/prescient.el/pull/106
+[#110]: https://github.com/raxod502/prescient.el/pull/110
 
 ## 5.1 (released 2021-02-26)
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog].
   `M-s c`.  See [#105].
 
 ### Enhancements
+* `prescient-filter-method` accepts a function which returns the
+  desired filter methods ([#110])
 * `selectrum-prescient.el`: Match faces are now combined with faces
   that might be already present on candidates instead of replacing
   them which gives better visual results in these cases ([#101],

--- a/prescient.el
+++ b/prescient.el
@@ -116,6 +116,9 @@ is similar to `prefix', but allows for less typing.
 Value can also be a list of any of the above methods, in which
 case each method will be applied in order until one matches.
 
+Value can also be a function which returns any of the allowable
+values documented above.
+
 For backwards compatibility, the value of this variable can also
 be `literal+initialism', which equivalent to the list (`literal'
 `initialism')."
@@ -547,7 +550,10 @@ enclose literal substrings with capture groups."
                      (message
                       "No function in `prescient-filter-alist' for method: %s"
                       method)))
-                 (pcase prescient-filter-method
+                 (pcase
+                     (if (functionp prescient-filter-method)
+                         (funcall prescient-filter-method)
+                       prescient-filter-method)
                    ;; We support `literal+initialism' for backwards
                    ;; compatibility.
                    (`literal+initialism '(literal initialism))

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -174,8 +174,14 @@ buffer. It does not affect the default behavior (determined by
              ;; be a list of only one filter type.
              (setq prescient-filter-method '(,filter-type))
 
-           ;; Otherwise, if we need to add or remove from the list,
-           ;; make sure it's actually a list and not just a symbol.
+           ;; Otherwise, if the current setting is a function,
+           ;; evaluate it to get the value.
+           (when (functionp prescient-filter-method)
+             (setq prescient-filter-method
+                   (funcall prescient-filter-method)))
+
+           ;; If we need to add or remove from the list, make sure
+           ;; it's actually a list and not just a symbol.
            (when (symbolp prescient-filter-method)
              (setq prescient-filter-method
                    (list prescient-filter-method)))


### PR DESCRIPTION
Fixes #83. The use case is to be able to use different filter methods depending on the type of completions. I am testing this with the following config:

```elisp
(defun ps/filter-method ()
  (let ((completion-category
         (completion-metadata-get
          (completion-metadata (minibuffer-contents)
                               minibuffer-completion-table
                               minibuffer-completion-predicate)
          'category)))
    (cond ((eql completion-category 'file)          '(fuzzy))
          ((eql completion-category 'command)       '(fuzzy))
          ((eql completion-category 'consult-multi) '(fuzzy))
          (t                                        '(literal regexp initialism)))))


(setq prescient-filter-method 'ps/filter-method)
```

I am an elisp beginner—hopefully I've done this correctly 😄 
