### PR TITLE
Fix 'wrong-type-argument' error with ivy-prescient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### Bugs fixed
+* ivy doesn't convert all variables to string when sorting or calling
+  `prescient-remember`, so it need to preprocess when work with
+  `ivy-prescient.el`. if not, an `wrong-type-argument` error may 
+  occur. This issue affects the use of `format-all-buffer` ([#119]).
+
+[#119]: https://github.com/raxod502/prescient.el/pull/119
+
 ## 5.2 (released 2021-12-27)
 ### New features
 * Two new user options, `selectrum-prescient-enable-filtering` and

--- a/ivy-prescient.el
+++ b/ivy-prescient.el
@@ -117,9 +117,9 @@ In addition to string, ivy accepts many types of data, so some
 processing is needed to ensure that `prescient' can handle them."
   (if (stringp element)
       element
-    (cond ((symbolp element) (symbol-name element))
-          ((consp element) (symbol-name (car element)))
-          ((listp element) (car element)))))
+    (if (consp element)
+        (ivy-prescient--elements-ensure (car element))
+      (symbol-name element))))
 
 (defun ivy-prescient-sort-function (c1 c2)
   "Comparison function that uses prescient.el to sort candidates.


### PR DESCRIPTION

ivy doesn't convert all variables to string when sorting or calling `prescient-remember`, so it need to preprocess when work with `ivy-prescient.el`. if not, a `wrong-type-argument` error may occur.