### PR TITLE
Fix advices.

### DIFF
--- a/corfu-prescient.el
+++ b/corfu-prescient.el
@@ -199,7 +199,7 @@ This mode will:
         ;; While sorting might not be enabled in Corfu, it might
         ;; still be enabled in another UI, such as Selectrum or Vertico.
         ;; Therefore, we still want to remember candidates.
-        (advice-add 'corfu-insert :after #'corfu-prescient--remember))
+        (advice-add 'corfu--insert :before #'corfu-prescient--remember))
 
     ;; Turn off mode.
 

--- a/vertico-prescient.el
+++ b/vertico-prescient.el
@@ -178,7 +178,7 @@ This mode will:
         ;; While sorting might not be enabled in Vertico, it might
         ;; still be enabled in another UI, such as Company or Corfu.
         ;; Therefore, we still want to remember candidates.
-        (advice-add 'vertico-insert :after #'vertico-prescient--remember))
+        (advice-add 'vertico-insert :before #'vertico-prescient--remember))
 
     ;; Turn off mode.
 


### PR DESCRIPTION
- Advise `corfu--insert`, not `corfu-insert`.
- Move Corfu advice to before `corfu--insert`.
- Move Vertico to before `vertico-insert` (only 1 "-") just to be safe.

Problem found in issue #135.