### PR TITLE
Vertico Prescient: Advise `vertico--setup` instead of adding to `minibuffer-setup-hook`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### Bugs fixed
+* Only set up `vertico-prescient` remembrance functions in Vertico
+  minibuffers, not in all minibuffers ([#172], [#173]).
+
+  Previously, remembrance functions were added to
+  `minibuffer-setup-hook`, which was accidentally recording minibuffer
+  contents for all uses of the minibuffer, such as `read-passwd`. If
+  `vertico-prescient-mode` and `prescient-persist-mode` were both
+  active, then it was possible for passwords to have been saved to
+  disk.  Users should check the contents of `prescient-save-file`.
+
+  The remembrance functions are now set up by advising
+  `vertico--setup`, which should mean that they are only set up within
+  Vertico buffers, not minibuffers in general.
+
+[#172]: https://github.com/radian-software/prescient.el/pull/172
+[#173]: https://github.com/radian-software/prescient.el/pull/173
+
 ## 6.3.2 (released 2025-08-15)
 ### Enchancements
 * Give `prescient-save.el` a lexical binding cookie to avoid

--- a/vertico-prescient.el
+++ b/vertico-prescient.el
@@ -246,8 +246,8 @@ This mode will:
         ;; While sorting might not be enabled in Vertico, it might
         ;; still be enabled in another UI, such as Company or Corfu.
         ;; Therefore, we still want to remember candidates.
-        (add-hook 'minibuffer-setup-hook
-                  #'vertico-prescient--setup-remembrance))
+        (advice-add 'vertico--setup
+                    :after #'vertico-prescient--setup-remembrance))
 
     ;; Turn off mode.
 
@@ -275,8 +275,8 @@ This mode will:
           (vertico-prescient--undo-completion-settings))))
 
     ;; Undo remembrance settings.
-    (remove-hook 'minibuffer-setup-hook
-                 #'vertico-prescient--setup-remembrance)))
+    (advice-remove 'vertico--setup
+                   #'vertico-prescient--setup-remembrance)))
 
 (provide 'vertico-prescient)
 ;;; vertico-prescient.el ends here


### PR DESCRIPTION
Use `vertico--setup` instead of `minibuffer-setup-hook` to trigger `vertico-prescient--setup-remembrance`.  Otherwise, `vertico-prescient--setup-remembrance` will run in minibuffers that are not Vertico minibuffers, such as from `read-passwd`.

`vertico-prescient.el` already advises `vertico--setup` to run `vertico-prescient--apply-completion-settings`.